### PR TITLE
10 handle dropped nodes

### DIFF
--- a/client.js
+++ b/client.js
@@ -21,6 +21,7 @@ let client;
 
 // Used by Crawl to accumulate data about the Chord ring
 const bigBucketOfData = {};
+const ring = new Set([]);
 let lastNode;
 
 function fetch({ _: args }) {
@@ -97,11 +98,32 @@ async function crawl(){
   client.getSuccessor_remotehelper({id: 99}, (err, node) => {
     if (err) {
       console.log(err);
-      console.log(node);
+      let nodeToDelete = lastNode.id;
+      // Remove the node from the bucket and select a random node
+      for (elem in Object.keys(bigBucketOfData)){ 
+        if (elem && bigBucketOfData[elem] && bigBucketOfData[elem].successor && bigBucketOfData[elem].successor.id && bigBucketOfData[elem].successor.id !== lastNode.id) {
+          lastNode = bigBucketOfData[elem].successor;
+          break;
+        }
+      }
+      delete bigBucketOfData[nodeToDelete];
+      
     } else {
       if (bigBucketOfData[lastNode.id]){
         bigBucketOfData[lastNode.id].successor = node; 
       }
+
+      // If we've walked the logical ring and we didn't touch a node, delete it
+      if (ring.has(node.id)) {
+        for (elem of Object.keys(bigBucketOfData)){ 
+          console.log(bigBucketOfData[elem]);
+          if (!ring.has(bigBucketOfData[elem].id)){
+            delete bigBucketOfData[elem];
+          }
+        }
+        ring.clear();
+      }
+      ring.add(node.id);
       bigBucketOfData[node.id] = {...bigBucketOfData[node.id], ...node};
       lastNode = node;
     }

--- a/client.js
+++ b/client.js
@@ -94,7 +94,7 @@ function summary(){
 async function crawl(){
   client = new chord.Node(`${lastNode.ip}:${lastNode.port}`, grpc.credentials.createInsecure());
   // The argument is total garbage
-  client.getSuccessor_remote({id: 99}, (err, node) => {
+  client.getSuccessor_remotehelper({id: 99}, (err, node) => {
     if (err) {
       console.log(err);
       console.log(node);

--- a/node.js
+++ b/node.js
@@ -531,7 +531,6 @@ async function join(known_node) {
  * @returns {boolean}
  */
 function confirm_exist(known_node) {
-    // TODO: confirm_exist actually needs to ping the endpoint to ensure it's real
     return !(_self.id == known_node.id);
 }
 

--- a/node.js
+++ b/node.js
@@ -1,9 +1,6 @@
 /**
  * Implements a node in a Chord, per Stoica et al., ca 2001. 
  * 
- * @requires gRPC
- * 
- * @version 20191103
  */
 
 const path = require("path");
@@ -51,7 +48,6 @@ let predecessor = NULL_NODE;
  * 
  * @returns true if the input value is in - modulo - bounds; false otherwise
  * 
- * @version 20191103
  */
 function isInModuloRange(input_value, lower_bound, include_lower, upper_bound, include_upper) {
     /*
@@ -136,7 +132,6 @@ function insert({ request: user }, callback) {
  * @argument node_queried node being queried for the ID
  * @returns id.successor
  * 
- * @version 20191103
  */
 async function find_successor(id, node_querying, node_queried) {
     // enable debugging output
@@ -199,7 +194,6 @@ async function find_successor(id, node_querying, node_queried) {
  * 
  * @argument id_and_node_queried {id:, node:}, where ID is the key sought
  * 
- * @version 20191103
  */
 async function find_successor_remotehelper(id_and_node_queried, callback) {
     // enable debugging output
@@ -233,7 +227,6 @@ async function find_successor_remotehelper(id_and_node_queried, callback) {
  * 
  * @todo 20191103.hk: re-examine the limits on the while loop
  * @argument id the key sought
- * @version 20191103
 */
 async function find_predecessor(id) {
     // enable debugging output
@@ -309,7 +302,6 @@ async function find_predecessor(id) {
  * If the querying node is the same as the queried node, it will be a local lookup.
  * 
  * @returns : the successor if the successor seems valid, or a null node otherwise
- * @version 20191103
  */
 async function getSuccessor(node_querying, node_queried) {
     // enable debugging output
@@ -353,7 +345,6 @@ async function getSuccessor(node_querying, node_queried) {
  * RPC equivalent of the getSuccessor() method.
  * It is implemented as simply a wrapper for the getSuccessor() function.
  * 
- * @version 20191103
  */
 async function getSuccessor_remotehelper(thing, callback) {
     callback(null, FingerTable[0].successor);
@@ -367,7 +358,6 @@ async function getSuccessor_remotehelper(thing, callback) {
  * 
  * @returns the closest preceding node to ID
  * 
- * @version 20191103
  */
 async function closest_preceding_finger(id, node_querying, node_queried) {
     let n_preceding = NULL_NODE;
@@ -407,7 +397,6 @@ async function closest_preceding_finger(id, node_querying, node_queried) {
  * 
  * @argument id_and_node_queried {id:, node:}, where ID is the key sought
  * 
- * @version 20191103
  */
 async function closest_preceding_finger_remotehelper(id_and_node_queried, callback) {
     const id = id_and_node_queried.request.id;
@@ -426,7 +415,6 @@ async function closest_preceding_finger_remotehelper(id_and_node_queried, callba
  * 
  * @argument : NONE
  * @returns predecessor node
- * @version 20191103
  */
 async function getPredecessor(thing, callback) {
     callback(null, predecessor);
@@ -436,7 +424,6 @@ async function getPredecessor(thing, callback) {
  * RPC to replace the value of the node's predecessor.
  * 
  * @argument message is a node object
- * @version 20191103
  */
 async function setPredecessor(message, callback) {
     // enable debugging output
@@ -467,7 +454,6 @@ async function setPredecessor(message, callback) {
  * 
  * @argument known_node: known_node structure; e.g., {id, ip, port}
  *   Pass a null known node to force the node to be the first in a new chord.
- * @version 20191103
  */
 async function join(known_node) {
     // enable debugging output
@@ -510,7 +496,6 @@ async function join(known_node) {
 /**
  * Determine whether a node exists by pinging it.
  * 
- * @version 20191103
  */
 function confirm_exist(known_node) {
     // TODO: confirm_exist actually needs to ping the endpoint to ensure it's real
@@ -520,7 +505,6 @@ function confirm_exist(known_node) {
 /**
  * Directly implement the pseudocode's init_finger_table() method.
  * 
- * @version 20191103
  */
 async function init_finger_table(n_prime) {
     // enable debugging output
@@ -591,7 +575,6 @@ async function init_finger_table(n_prime) {
 /**
  * Directly implement the pseudocode's update_others() method.
  * 
- * @version 20191102
  */
 async function update_others() {
     // enable debugging output
@@ -649,7 +632,6 @@ async function update_others() {
  * RPC that directly implements the pseudocode's update_finger_table() method.
  * 
  * @argument message : consists of {s_node, finger_index} * 
- * @version 20191102
  */
 async function update_finger_table(message, callback) {
     // enable debugging output
@@ -710,7 +692,6 @@ async function update_finger_table(message, callback) {
  * 
  * @returns : true if it was successful; false otherwise.
  * 
- * @version 20191103
  */
 async function update_successor_table() {
     // enable debugging output
@@ -818,7 +799,6 @@ async function update_successor_table() {
  *      as would be the case for the initial node in a chord.
  *  2- additional step of updating the successor table as recommended by the IEEE paper.
  *
- * @version 20191103
  */
 async function stabilize() {
     // enable debugging output
@@ -888,7 +868,6 @@ async function stabilize() {
  * This is an original function, not described in either version of the paper - added 20191021.
  *
  * @returns : true if it was a good kick; false if bad kick.
- * @version 20191103
 */
 async function stabilize_self() {
     let predecessor_seems_ok = false;
@@ -923,7 +902,6 @@ async function stabilize_self() {
 /**
  * Directly implements the pseudocode's notify() method.
  * 
- * @version 20191021
  */
 async function notify(message, callback) {
     const n_prime = message.request;
@@ -939,7 +917,6 @@ async function notify(message, callback) {
 /**
  * Directly implements the pseudocode's fix_fingers() method.
  * 
- * @version 20191103
  */
 async function fix_fingers() {
     // enable debugging output
@@ -968,7 +945,6 @@ async function fix_fingers() {
  * Directly implements the check_predecessor() method from the IEEE version of the paper.
  * 
  * @returns : true if predecessor was still reasonable; false otherwise.
- * @version 20191021
  */
 async function check_predecessor() {
     if ((predecessor.id !== null) && (predecessor.id !== _self.id)) {
@@ -991,7 +967,6 @@ async function check_predecessor() {
  * This is an original function, not described in either version of the paper - added 20191103.
  * 
  * @returns : true if successor was still reasonable; false otherwise.
- * @version 20191103
  */
 async function check_successor() {
     // enable debugging output
@@ -1030,7 +1005,6 @@ async function check_successor() {
 /**
  * Placeholder for data migration within the join() call.
  * 
- * @version 20191103
  */
 async function migrate_keys() {}
 
@@ -1047,7 +1021,6 @@ async function migrate_keys() {}
  * --targetIp   - The IP of a node in the cluster
  * --targetPort - The Port of a node in the cluster
  *
- * @version 20191021
  */
 async function main() {
     // enable debugging output

--- a/node.js
+++ b/node.js
@@ -29,14 +29,14 @@ const CHECK_NODE_TIMEOUT_ms = 1000;
 
 const NULL_NODE = { id: null, ip: null, port: null };
 
-let FingerTable = [
+let fingerTable = [
     {
         start: null,
         successor: NULL_NODE
     }
 ];
 
-let SuccessorTable = [ NULL_NODE ];
+let successorTable = [ NULL_NODE ];
 
 let _self = NULL_NODE;
 

--- a/node.js
+++ b/node.js
@@ -169,6 +169,7 @@ async function find_successor(id, node_querying, node_queried) {
         try {
             n_prime = await find_predecessor(id);
         } catch (err) {
+            console.error(`find_successor's call to find_predecessor failed with `, err);
             n_prime = NULL_NODE;
         }
 
@@ -180,6 +181,7 @@ async function find_successor(id, node_querying, node_queried) {
         try {
             n_prime_successor = await getSuccessor(_self, n_prime);
         } catch (err) {
+            console.error(`find_successor's call to getSuccessor failed with `, err);
             n_prime_successor = NULL_NODE;
         }
 
@@ -194,7 +196,7 @@ async function find_successor(id, node_querying, node_queried) {
             n_prime_successor = await node_queried_client.find_successor_remotehelper({ id: id, node: node_queried });
         } catch (err) {
             n_prime_successor = NULL_NODE;
-            console.error("Remote error in find_successor() ", err);
+            console.error("find_successor call to find_successor_remotehelper failed with", err);
         }
     }
 
@@ -231,6 +233,7 @@ async function find_successor_remotehelper(id_and_node_queried, callback) {
     try {
         n_prime_successor = await find_successor(id, _self, node_queried);
     } catch (err) {
+        console.error("n_prime_successor call to find_successor failed with", err);
         n_prime_successor = NULL_NODE;
     }
     callback(null, n_prime_successor);
@@ -264,6 +267,7 @@ async function find_predecessor(id) {
     try {
         n_prime_successor = await getSuccessor(_self, n_prime);
     } catch (err) {
+        console.error("find_predecessor call to getSuccessor failed with", err);
         n_prime_successor = NULL_NODE;
     }
 
@@ -298,6 +302,7 @@ async function find_predecessor(id) {
         try {
             n_prime_successor = await getSuccessor(_self, n_prime);
         } catch (err) {
+            console.error("find_predecessor call to getSuccessor (2) failed with", err);
             n_prime_successor = NULL_NODE;
         }
 
@@ -348,9 +353,7 @@ async function getSuccessor(node_querying, node_queried) {
         } catch (err) {
             // TBD 20191103.hk: why does "n_successor = NULL_NODE;" not do the same as explicit?!?!
             n_successor = {id: null, ip: null, port: null};
-            if (DEBUGGING_LOCAL) {
-                console.trace("Remote error in getSuccessor() ", err);
-            }
+            console.trace("Remote error in getSuccessor() ", err);
         }
     }
 
@@ -409,7 +412,7 @@ async function closest_preceding_finger(id, node_querying, node_queried) {
             n_preceding = await node_queried_client.closest_preceding_finger_remotehelper({ id: id, node: node_queried });
         } catch (err) {
             n_preceding = NULL_NODE;
-            console.error("Remote error in closest_preceding_finger() ", err);
+            console.error("closest_preceding_finger call to closest_preceding_finger_remotehelper failed with ", err);
         }
         // return n;
         return n_preceding;
@@ -431,6 +434,7 @@ async function closest_preceding_finger_remotehelper(id_and_node_queried, callba
     try {
         n_preceding = await closest_preceding_finger(id, _self, node_queried);
     } catch (err) {
+        console.error("closest_preceding_finger_remotehelper call to closest_preceding_finger failed with ", err);
         n_preceding = NULL_NODE;
     }
     callback(null, n_preceding);
@@ -550,7 +554,7 @@ async function init_finger_table(n_prime) {
         n_prime_successor = await find_successor(fingerTable[0].start, _self, n_prime);
     } catch (err) {
         n_prime_successor = NULL_NODE;
-        console.error("find_successor error in init_finger_table() ", err);
+        console.error("init_finger_table call to find_successor failed with ", err);
     }
     // finger[1].node = n'.find_successor(finger[1].start);
     fingerTable[0].successor = n_prime_successor;
@@ -566,13 +570,13 @@ async function init_finger_table(n_prime) {
         predecessor = await successor_client.getPredecessor(fingerTable[0].successor);
     } catch (err) {
         predecessor = NULL_NODE;
-        console.error("getPredecessor error in init_finger_table() ", err);
+        console.error("init_finger_table call to getPredecessor failed with", err);
     }
     // successor.predecessor = n;
     try {
         await successor_client.setPredecessor(_self);
     } catch (err) {
-        console.error("setPredecessor() error in init_finger_table() ", err);
+        console.error("init_finger_table call to setPredecessor() failed with ", err);
     }
 
     if (DEBUGGING_LOCAL) {
@@ -591,7 +595,7 @@ async function init_finger_table(n_prime) {
                 fingerTable[i + 1].successor = await find_successor(fingerTable[i + 1].start, _self, n_prime);
             } catch (err) {
                 fingerTable[i + 1].successor = NULL_NODE;
-                console.error("find_successor error in init_finger_table ", err);
+                console.error("init_finger_table call to find_successor() failed with ", err);
             }
         }
     }
@@ -634,7 +638,7 @@ async function update_others() {
             p_node = await find_predecessor(p_node_search_id);
         } catch (err) {
             p_node = NULL_NODE;
-            console.error("\nError from find_predecessor(", p_node_search_id, ") in update_others().\n");
+            console.error("Error from find_predecessor(", p_node_search_id, ") in update_others().", err);
         }
 
         if (DEBUGGING_LOCAL) {
@@ -737,6 +741,7 @@ async function update_successor_table() {
     try {
         successor_seems_ok = await check_successor();
     } catch (err) {
+        console.error(`update_successor_table call to check_successor failed with `, err);
         successor_seems_ok = false;
     }
     if (successor_seems_ok) {
@@ -749,6 +754,7 @@ async function update_successor_table() {
             try {
                 successor_seems_ok = await check_successor();
             } catch (err) {
+                console.error(`update_successor_table call to check_successor failed with `, err);
                 successor_seems_ok = false;
             }
             if (successor_seems_ok) {
@@ -778,6 +784,7 @@ async function update_successor_table() {
             try {
                 successor_successor = await getSuccessor(_self, successorTable[i]);
             } catch (err) {
+                console.error(`update_successor_table call to getSuccessor failed with `, err);
                 successor_successor = {id: null, ip: null, port: null};
             }
             if (DEBUGGING_LOCAL) {
@@ -803,6 +810,7 @@ async function update_successor_table() {
                 successor_seems_ok = true;
             }
         } catch (err) {
+            console.error(`update_successor_table call to getSuccessor failed with `, err);
             successor_seems_ok = false;
             successor_successor = NULL_NODE;
         }
@@ -839,6 +847,7 @@ async function stabilize() {
     try {
         successor_client = caller(`localhost:${fingerTable[0].successor.port}`, PROTO_PATH, "Node");
     } catch {
+        console.error(`stabilize call to caller failed with `, err);
         return false;
     }
     // x = successor.predecessor;
@@ -877,7 +886,7 @@ async function stabilize() {
         try {
             await successor_client.notify(_self);
         } catch (err) {
-            // no need for handler
+            console.error(`stabilize call to successor_client.notify failed with `, err);
         }
     }
 
@@ -886,7 +895,7 @@ async function stabilize() {
     try {
         await update_successor_table();
     } catch (err) {
-        // probably no need for error handler
+        console.error(`stabilize call to update_successor_table failed with `, err);
     }
     /* TBD 20191103 */
     return true;
@@ -914,7 +923,7 @@ async function stabilize_self() {
             predecessor_seems_ok = await check_predecessor();
         } catch (err) {
             predecessor_seems_ok = false;
-            console.error(err);
+            console.error(`stabilize_self call to check_predecessor failed with `, err);
         }
         if (predecessor_seems_ok) {
             // then kick by setting the successor to the same as the predecessor
@@ -965,7 +974,7 @@ async function fix_fingers() {
             fingerTable[i].successor = n_successor;
         }
     } catch (err) {
-        // don't change the finger just yet
+        console.error(`fix_fingers call to find_successor failed with `, err);
     }
     if (DEBUGGING_LOCAL) {
         console.log("\n>>>>>     Fix {", _self.id, "}.fingerTable[", i, "], with start = ", fingerTable[i].start, ".");
@@ -985,7 +994,7 @@ async function check_predecessor() {
             // just ask anything
             const x = await predecessor_client.getPredecessor(_self.id);
         } catch (err) {
-            // predecessor = nil;
+            console.error(`check_predecessor call to getPredecessor failed with `, err);
             predecessor = { id: null, ip: null, port: null };
             return false;
         }
@@ -1026,9 +1035,7 @@ async function check_successor() {
             }
         } catch (err) {
             successor_seems_ok = false;
-            if (DEBUGGING_LOCAL) {
-                console.log("Error in check_successor({", _self.id, "})\n", err);
-            }
+            console.log("Error in check_successor({", _self.id, "}) call to getSuccessor", err);
         }
     }
     return successor_seems_ok;

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -17,7 +17,6 @@ service Node {
   // Chord Library Level RPC Calls
   rpc find_successor_remotehelper (RemoteId) returns (NodeAddress) {}
   rpc getSuccessor_remotehelper (NodeAddress) returns (NodeAddress) {}
-  rpc getSuccessorTable_remotehelper (NodeAddress) returns (SuccessorTable) {}
   rpc getPredecessor (NodeAddress) returns (NodeAddress) {}
   rpc setPredecessor (NodeAddress) returns (google.protobuf.Empty) {}
   rpc closest_preceding_finger_remotehelper (RemoteId) returns (NodeAddress) {}
@@ -44,10 +43,6 @@ message FingerTableEntry {
   NodeAddress node = 1;
   uint32 index = 2;
  }
-
-message SuccessorTable {
-  {NodeAddress} SuccessorTable = 1;
-}
 
 message Trash{
   uint32 id = 1;

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -15,18 +15,14 @@ service Node {
   rpc insert (User) returns (google.protobuf.Empty) {}
 
   // Chord Library Level RPC Calls
-  rpc getSuccessor_remote (NodeAddress) returns (NodeAddress) {}
+  rpc find_successor_remotehelper (RemoteId) returns (NodeAddress) {}
+  rpc getSuccessor_remotehelper (NodeAddress) returns (NodeAddress) {}
+  rpc getSuccessorTable_remotehelper (NodeAddress) returns (SuccessorTable) {}
   rpc getPredecessor (NodeAddress) returns (NodeAddress) {}
   rpc setPredecessor (NodeAddress) returns (google.protobuf.Empty) {}
+  rpc closest_preceding_finger_remotehelper (RemoteId) returns (NodeAddress) {}
   rpc notify (NodeAddress) returns (google.protobuf.Empty) {}
   rpc update_finger_table (FingerTableEntry) returns (NodeAddress) {}
-  rpc find_successor_remotehelper (RemoteId) returns (NodeAddress) {}
-  rpc closest_preceding_finger_remotehelper (RemoteId) returns (NodeAddress) {}
-}
-
-message RemoteId {
-  uint32 id = 1;
-  NodeAddress node = 2;
 }
 
 message NodeId {
@@ -39,14 +35,23 @@ message NodeAddress {
   uint32 port = 3;
 }
 
-message Trash{
+message RemoteId {
   uint32 id = 1;
+  NodeAddress node = 2;
 }
 
 message FingerTableEntry {
   NodeAddress node = 1;
   uint32 index = 2;
  }
+
+message SuccessorTable {
+  {NodeAddress} SuccessorTable = 1;
+}
+
+message Trash{
+  uint32 id = 1;
+}
 
 // The request message containing the user's name.
 message UserRequest {


### PR DESCRIPTION
This branch introduces the necessary feature to address issue #10 .

In the process of doing that, it also handled the overwhelming majority of issue #17 .

Nodes can be killed (e.g., ctrl + c) and the chord will stabilize in *most* circumstances.  This has been tested with up to 16 nodes.  In general, if too many nodes are killed too quickly relative to a stabilization interval (currently ~3 seconds), the algorithm has trouble.  Also, it is possible that if too many consecutive nodes are killed not too fast, the algorithm might have trouble - a bit more testing is needed after some sleep.  Some issues with the crawler were observed but it is possible that the problem is with the crawler's internal data structure - only minor attempt at troubleshooting was done since the console shows the successortable updating more or less in lockstep with the finger tables.

In any event, my recommendation is to merge this as the baseline since it is a significant improvement over the prior version.  A new issue to improve on this algorithm has been instantiated as #31 .