### PR TITLE
chore: add prettier and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,py}]
+charset = utf-8
+
+indent_style = space
+indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "zxh404.vscode-proto3"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "zxh404.vscode-proto3"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "zxh404.vscode-proto3",
+    "editorconfig.editorconfig"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,14 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Program",
-            "program": "${workspaceFolder}/index.js"
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/index.js"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Chord (Node.js and gRPC)
 
-This project is an implementation of a p2p distributed hash table using the Chord algorithm by Ion Stoica, Robert Morris, David Karger, Kaashoek, and Hari Balakrishnan. It uses Node.js to implement the nodes, and gRPC as the method of inter-node communiation. 
+This project is an implementation of a p2p distributed hash table using the Chord algorithm by Ion Stoica, Robert Morris, David Karger, Kaashoek, and Hari Balakrishnan. It uses Node.js to implement the nodes, and gRPC as the method of inter-node communiation.
 
-The client script: 
-* runs a crawler that walks the Chord successor chain to build an in-memory representaiton of the state of the overlay network
-* serves a simple web UI that visualizes the overlay network
+The client script:
+
+- runs a crawler that walks the Chord successor chain to build an in-memory representaiton of the state of the overlay network
+- serves a simple web UI that visualizes the overlay network
 
 In the future, the project will implement a "Stack Exchange Computer Science User Service" on top of this DHT, complete with a simple web app to demonstrate transparency and real-work use of a DHT. It will also enhance the admin pain to add controls to dynamically add and remove nodes from the Chord.
-
 
 ## To Run
 
@@ -34,6 +34,7 @@ node client crawl --ip localhost --port 8440 --webPort 1337
 Then open localhost:1337 in a browser
 
 Then run the following commands one at a time in separate tabs:
+
 ```
 node node --ip localhost --port 8441 --id 6 --targetIp localhost --targetPort 8440 --targetId 0
 node node --ip localhost --port 8442 --id 1 --targetIp localhost --targetPort 8440 --targetId 0

--- a/cleanData.js
+++ b/cleanData.js
@@ -1,38 +1,40 @@
-const fs = require('fs');
-const parseString = require('xml2js').parseString;
+const fs = require("fs");
+const parseString = require("xml2js").parseString;
 
 const COUNT_OF_USERS_IN_TINY_USERS = 100;
 
 // Quick and dirty script to convert the StackOverflow data from XML to JSON
 fs.readFile(`${__dirname}/data/users.xml`, (err, data) => {
-    parseString(data, (err, rawData) => {
-        
-        const result = {};
-        const tinyResult = {};
-        rawData.users.row
-        .map(person => person['$'])
-        .map(person => ({
-            id: parseInt(person.Id, 10),
-            reputation: parseInt(person.Reputation, 10),
-            creationDate: person.CreationDate,
-            displayName: person.DisplayName,
-            lastAccessDate: person.LastAccessDate,
-            websiteUrl: person.WebsiteUrl,
-            location: person.Location,
-            aboutMe: person.AboutMe,
-            views: parseInt(person.Views, 10),
-            upVotes: parseInt(person.UpVotes, 10),
-            downVotes: parseInt(person.DownVotes, 10),
-            profileImageUrl: person.ProfileImageUrl,
-            accountId: parseInt(person.AccountId, 10),
-        }))
-        .forEach((person, idx) => {
-            if (idx < COUNT_OF_USERS_IN_TINY_USERS){
-                tinyResult[person.id] = person;
-            }
-            result[person.id] = person;
-        })
-        fs.writeFileSync(`${__dirname}/data/users.json`, JSON.stringify(result));
-        fs.writeFileSync(`${__dirname}/data/tinyUsers.json`, JSON.stringify(tinyResult));
-    });
+  parseString(data, (err, rawData) => {
+    const result = {};
+    const tinyResult = {};
+    rawData.users.row
+      .map(person => person["$"])
+      .map(person => ({
+        id: parseInt(person.Id, 10),
+        reputation: parseInt(person.Reputation, 10),
+        creationDate: person.CreationDate,
+        displayName: person.DisplayName,
+        lastAccessDate: person.LastAccessDate,
+        websiteUrl: person.WebsiteUrl,
+        location: person.Location,
+        aboutMe: person.AboutMe,
+        views: parseInt(person.Views, 10),
+        upVotes: parseInt(person.UpVotes, 10),
+        downVotes: parseInt(person.DownVotes, 10),
+        profileImageUrl: person.ProfileImageUrl,
+        accountId: parseInt(person.AccountId, 10)
+      }))
+      .forEach((person, idx) => {
+        if (idx < COUNT_OF_USERS_IN_TINY_USERS) {
+          tinyResult[person.id] = person;
+        }
+        result[person.id] = person;
+      });
+    fs.writeFileSync(`${__dirname}/data/users.json`, JSON.stringify(result));
+    fs.writeFileSync(
+      `${__dirname}/data/tinyUsers.json`,
+      JSON.stringify(tinyResult)
+    );
+  });
 });

--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
-const grpc = require('grpc');
-const protoLoader = require('@grpc/proto-loader');
-const minimist = require('minimist')
+const grpc = require("grpc");
+const protoLoader = require("@grpc/proto-loader");
+const minimist = require("minimist");
 const packageDefinition = protoLoader.loadSync(
   `${__dirname}/protos/chord.proto`,
   {
@@ -9,12 +9,13 @@ const packageDefinition = protoLoader.loadSync(
     enums: String,
     defaults: true,
     oneofs: true
-  });
+  }
+);
 
 const target = {
   ip: `localhost`,
   port: 1337
-}
+};
 
 const chord = grpc.loadPackageDefinition(packageDefinition).chord;
 let client;
@@ -41,14 +42,17 @@ function fetch({ _: args }) {
 
 // I was originally thinking that the user service would assign the id, but this doesn't really seem possible...
 
-
 function insert({ _, ...rest }) {
   if (!rest.id) {
     console.log("id is a mandatory field!");
     console.log("node client insert --id=42424242");
 
-    console.log("optional fields include reputation, creationDate, displayName, lastAccessDate, websiteUrl, location, aboutMe, views, upVotes, downVotes, profileImageUrl, accountId");
-    console.log('node client insert --id=42424242 --displayName="Sean McBride" --reputation=3 --website="https://www.bushido.codes"');
+    console.log(
+      "optional fields include reputation, creationDate, displayName, lastAccessDate, websiteUrl, location, aboutMe, views, upVotes, downVotes, profileImageUrl, accountId"
+    );
+    console.log(
+      'node client insert --id=42424242 --displayName="Sean McBride" --reputation=3 --website="https://www.bushido.codes"'
+    );
     process.exit();
   }
   console.log(rest);
@@ -65,7 +69,7 @@ function insert({ _, ...rest }) {
     upVotes: rest.upVotes || 0,
     downVotes: rest.downVotes || 0,
     profileImageUrl: rest.profileImageUrl || 0,
-    accountId: rest.accoutId || 0,
+    accountId: rest.accoutId || 0
   };
   console.log(user);
   client.insert(user, (err, user) => {
@@ -78,58 +82,67 @@ function insert({ _, ...rest }) {
 }
 
 //Requests basic information about the target node
-function summary(){
-  console.log("Client requesting summary:")
-  client.summary({id: 1}, (err, node) => {
+function summary() {
+  console.log("Client requesting summary:");
+  client.summary({ id: 1 }, (err, node) => {
     if (err) {
       console.log(err);
       console.log(node);
     } else {
       //console.log(node);
-      console.log(`The node returned id: ${node.id}, ip: ${node.ip}, port: ${node.port}`);
+      console.log(
+        `The node returned id: ${node.id}, ip: ${node.ip}, port: ${node.port}`
+      );
     }
   });
 }
 
 //Requests basic information about the target node
-async function crawl(){
-  client = new chord.Node(`${lastNode.ip}:${lastNode.port}`, grpc.credentials.createInsecure());
+async function crawl() {
+  client = new chord.Node(
+    `${lastNode.ip}:${lastNode.port}`,
+    grpc.credentials.createInsecure()
+  );
   // The argument is total garbage
-  client.getSuccessor_remotehelper({id: 99}, (err, node) => {
+  client.getSuccessor_remotehelper({ id: 99 }, (err, node) => {
     if (err) {
       console.log(err);
       let nodeToDelete = lastNode.id;
       // Remove the node from the bucket and select a random node
-      for (elem in Object.keys(bigBucketOfData)){ 
-        if (elem && bigBucketOfData[elem] && bigBucketOfData[elem].successor && bigBucketOfData[elem].successor.id && bigBucketOfData[elem].successor.id !== lastNode.id) {
+      for (elem in Object.keys(bigBucketOfData)) {
+        if (
+          elem &&
+          bigBucketOfData[elem] &&
+          bigBucketOfData[elem].successor &&
+          bigBucketOfData[elem].successor.id &&
+          bigBucketOfData[elem].successor.id !== lastNode.id
+        ) {
           lastNode = bigBucketOfData[elem].successor;
           break;
         }
       }
       delete bigBucketOfData[nodeToDelete];
-      
     } else {
-      if (bigBucketOfData[lastNode.id]){
-        bigBucketOfData[lastNode.id].successor = node; 
+      if (bigBucketOfData[lastNode.id]) {
+        bigBucketOfData[lastNode.id].successor = node;
       }
 
       // If we've walked the logical ring and we didn't touch a node, delete it
       if (ring.has(node.id)) {
-        for (elem of Object.keys(bigBucketOfData)){ 
+        for (elem of Object.keys(bigBucketOfData)) {
           console.log(bigBucketOfData[elem]);
-          if (!ring.has(bigBucketOfData[elem].id)){
+          if (!ring.has(bigBucketOfData[elem].id)) {
             delete bigBucketOfData[elem];
           }
         }
         ring.clear();
       }
       ring.add(node.id);
-      bigBucketOfData[node.id] = {...bigBucketOfData[node.id], ...node};
+      bigBucketOfData[node.id] = { ...bigBucketOfData[node.id], ...node };
       lastNode = node;
     }
   });
 }
-
 
 function main() {
   if (process.argv.length >= 3) {
@@ -143,32 +156,48 @@ function main() {
     }
 
     console.log(`Connecting to ${target.ip}:${target.port}`);
-    
+
     const command = process.argv[2];
-    
+
     switch (command) {
       case "fetch":
-        client = new chord.Node(`${target.ip}:${target.port}`, grpc.credentials.createInsecure());
+        client = new chord.Node(
+          `${target.ip}:${target.port}`,
+          grpc.credentials.createInsecure()
+        );
         fetch(args);
         break;
       case "insert":
-        client = new chord.Node(`${target.ip}:${target.port}`, grpc.credentials.createInsecure());
+        client = new chord.Node(
+          `${target.ip}:${target.port}`,
+          grpc.credentials.createInsecure()
+        );
         insert(args);
         break;
       case "summary":
-        client = new chord.Node(`${target.ip}:${target.port}`, grpc.credentials.createInsecure());
+        client = new chord.Node(
+          `${target.ip}:${target.port}`,
+          grpc.credentials.createInsecure()
+        );
         summary();
         break;
       case "crawl":
-        client = new chord.Node(`${target.ip}:${target.port}`, grpc.credentials.createInsecure());
-        lastNode = {id: target.id, ip: target.ip, port: target.port};
-        setInterval(async () => { await crawl() }, 3000);
-        const express = require('express');
+        client = new chord.Node(
+          `${target.ip}:${target.port}`,
+          grpc.credentials.createInsecure()
+        );
+        lastNode = { id: target.id, ip: target.ip, port: target.port };
+        setInterval(async () => {
+          await crawl();
+        }, 3000);
+        const express = require("express");
         const app = express();
         const port = args.webPort || 3000;
-        app.use(express.static('public'))
-        app.get('/data', (req, res) => res.json(bigBucketOfData));
-        app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+        app.use(express.static("public"));
+        app.get("/data", (req, res) => res.json(bigBucketOfData));
+        app.listen(port, () =>
+          console.log(`Example app listening on port ${port}!`)
+        );
         break;
     }
   }

--- a/cryptoThread.js
+++ b/cryptoThread.js
@@ -1,3 +1,3 @@
 const CryptoJS = require("crypto-js");
-const { parentPort, workerData } = require('worker_threads');
-parentPort.postMessage(CryptoJS.SHA1(workerData).toString());  
+const { parentPort, workerData } = require("worker_threads");
+parentPort.postMessage(CryptoJS.SHA1(workerData).toString());

--- a/node.js
+++ b/node.js
@@ -1,6 +1,6 @@
 /**
- * Implements a node in a Chord, per Stoica et al., ca 2001. 
- * 
+ * Implements a node in a Chord, per Stoica et al., ca 2001.
+ *
  */
 
 const path = require("path");
@@ -13,11 +13,11 @@ const { Worker } = require("worker_threads");
 const PROTO_PATH = path.resolve(__dirname, "./protos/chord.proto");
 
 const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
-    keepCase: true,
-    longs: String,
-    enums: String,
-    defaults: true,
-    oneofs: true
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
 });
 
 const chord = grpc.loadPackageDefinition(packageDefinition).chord;
@@ -30,13 +30,13 @@ const CHECK_NODE_TIMEOUT_ms = 1000;
 const NULL_NODE = { id: null, ip: null, port: null };
 
 let fingerTable = [
-    {
-        start: null,
-        successor: NULL_NODE
-    }
+  {
+    start: null,
+    successor: NULL_NODE
+  }
 ];
 
-let successorTable = [ NULL_NODE ];
+let successorTable = [NULL_NODE];
 
 let _self = NULL_NODE;
 
@@ -45,281 +45,319 @@ let predecessor = NULL_NODE;
 /**
  * Accounts for the modulo arithmetic to determine whether the input value is within the bounds.
  * Implements inclusive and exclusive properties for each bound, as specified.
- * 
- * @param {number} input_value 
+ *
+ * @param {number} input_value
  * @param {number} lower_bound
  * @param {boolean} include_lower
  * @param {number} upper_bound
  * @param {boolean} include_upper
  * @returns {boolean} true if the input value is in - modulo - bounds; false otherwise
  */
-function isInModuloRange(input_value, lower_bound, include_lower, upper_bound, include_upper) {
-    /*
+function isInModuloRange(
+  input_value,
+  lower_bound,
+  include_lower,
+  upper_bound,
+  include_upper
+) {
+  /*
         USAGE
         include_lower == true means [lower_bound, ...
         include_lower == false means (lower_bound, ...
         include_upper == true means ..., upper_bound]
         include_upper == false means ..., upper_bound)
     */
-    if (include_lower && include_upper) {
-        if (lower_bound > upper_bound) {
-            //looping through 0
-            return (input_value >= lower_bound || input_value <= upper_bound);
-        } else {
-            return (input_value >= lower_bound && input_value <= upper_bound);
-        }
-    } else if (include_lower && !include_upper) {
-        if (lower_bound > upper_bound) {
-            //looping through 0
-            return (input_value >= lower_bound || input_value < upper_bound);
-        } else {
-            return (input_value >= lower_bound && input_value < upper_bound);
-        }
-    } else if (!include_lower && include_upper) {
-        if (lower_bound > upper_bound) {
-            //looping through 0
-            return (input_value > lower_bound || input_value <= upper_bound);
-        } else {
-            // start < end
-            return (input_value > lower_bound && input_value <= upper_bound);
-        }
+  if (include_lower && include_upper) {
+    if (lower_bound > upper_bound) {
+      //looping through 0
+      return input_value >= lower_bound || input_value <= upper_bound;
     } else {
-        //include neither
-        if (lower_bound > upper_bound) {
-            //looping through 0
-            return (input_value > lower_bound || input_value < upper_bound);
-        } else {
-            // start < end
-            return (input_value > lower_bound && input_value < upper_bound);
-        }
+      return input_value >= lower_bound && input_value <= upper_bound;
     }
+  } else if (include_lower && !include_upper) {
+    if (lower_bound > upper_bound) {
+      //looping through 0
+      return input_value >= lower_bound || input_value < upper_bound;
+    } else {
+      return input_value >= lower_bound && input_value < upper_bound;
+    }
+  } else if (!include_lower && include_upper) {
+    if (lower_bound > upper_bound) {
+      //looping through 0
+      return input_value > lower_bound || input_value <= upper_bound;
+    } else {
+      // start < end
+      return input_value > lower_bound && input_value <= upper_bound;
+    }
+  } else {
+    //include neither
+    if (lower_bound > upper_bound) {
+      //looping through 0
+      return input_value > lower_bound || input_value < upper_bound;
+    } else {
+      // start < end
+      return input_value > lower_bound && input_value < upper_bound;
+    }
+  }
 }
 
 /**
  * Print Summary of state of node
- * @param userRequestObject 
+ * @param userRequestObject
  * @param callback gRPC callback
  */
 function summary(_, callback) {
-    console.log("vvvvv     vvvvv     Summary     vvvvv     vvvvv");
-    console.log("fingerTable: \n", fingerTable);
-    console.log("Predecessor: ", predecessor);
-    console.log("^^^^^     ^^^^^     End Summary     ^^^^^     ^^^^^")
-    callback(null, _self);
+  console.log("vvvvv     vvvvv     Summary     vvvvv     vvvvv");
+  console.log("fingerTable: \n", fingerTable);
+  console.log("Predecessor: ", predecessor);
+  console.log("^^^^^     ^^^^^     End Summary     ^^^^^     ^^^^^");
+  callback(null, _self);
 }
 
 /**
  * Fetch a user
- * @param userRequestObject 
+ * @param userRequestObject
  * @param callback gRPC callback
  */
 function fetch({ request: { id } }, callback) {
-    console.log(`Requested User ${id}`);
-    if (!users[id]) {
-        callback({ code: 5 }, null); // NOT_FOUND error
-    } else {
-        callback(null, users[id]);
-    }
+  console.log(`Requested User ${id}`);
+  if (!users[id]) {
+    callback({ code: 5 }, null); // NOT_FOUND error
+  } else {
+    callback(null, users[id]);
+  }
 }
 
 /**
  * Insert a user
- * @param grpcRequest 
+ * @param grpcRequest
  * @param callback gRPC callback
  */
 function insert({ request: user }, callback) {
-    if (users[user.id]) {
-        const message = `Err: ${user.id} already exits`;
-        console.log(message);
-        callback({ code: 6, message }, null); // ALREADY_EXISTS error
-    } else {
-        users[user.id] = user;
-        const message = `Inserted User ${user.id}:`;
-        console.log(message);
-        callback({ status: 0, message }, null);
-    }
+  if (users[user.id]) {
+    const message = `Err: ${user.id} already exits`;
+    console.log(message);
+    callback({ code: 6, message }, null); // ALREADY_EXISTS error
+  } else {
+    users[user.id] = user;
+    const message = `Inserted User ${user.id}:`;
+    console.log(message);
+    callback({ status: 0, message }, null);
+  }
 }
 
 /**
  * Directly implement the pseudocode's find_successor() method.
- * 
+ *
  * However, it is able to discern whether to do a local lookup or an RPC.
  * If the querying node is the same as the queried node, it will stay local.
- * 
+ *
  * @param {number} id value being searched
  * @param node_querying node initiating the query
  * @param node_queried node being queried for the ID
  * @returns id.successor
- * 
+ *
  */
 async function find_successor(id, node_querying, node_queried) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    let n_prime = NULL_NODE;
-    let n_prime_successor = NULL_NODE;
+  let n_prime = NULL_NODE;
+  let n_prime_successor = NULL_NODE;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     find_successor     vvvvv     vvvvv");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     find_successor     vvvvv     vvvvv");
+  }
 
-    if (node_querying.id == node_queried.id) {
-        // use local value
-        // n' = find_predecessor(id);
-        try {
-            n_prime = await find_predecessor(id);
-        } catch (err) {
-            console.error(`find_successor's call to find_predecessor failed with `, err);
-            n_prime = NULL_NODE;
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("find_successor: n' is ", n_prime.id);
-        }
-
-        // get n'.successor either locally or remotely
-        try {
-            n_prime_successor = await getSuccessor(_self, n_prime);
-        } catch (err) {
-            console.error(`find_successor's call to getSuccessor failed with `, err);
-            n_prime_successor = NULL_NODE;
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("find_successor: n'.successor is ", n_prime_successor.id);
-        }
-    } else {
-        // create client for remote call
-        const node_queried_client = caller(`localhost:${node_queried.port}`, PROTO_PATH, "Node");
-        // now grab the remote value
-        try {
-            n_prime_successor = await node_queried_client.find_successor_remotehelper({ id: id, node: node_queried });
-        } catch (err) {
-            n_prime_successor = NULL_NODE;
-            console.error("find_successor call to find_successor_remotehelper failed with", err);
-        }
+  if (node_querying.id == node_queried.id) {
+    // use local value
+    // n' = find_predecessor(id);
+    try {
+      n_prime = await find_predecessor(id);
+    } catch (err) {
+      console.error(
+        `find_successor's call to find_predecessor failed with `,
+        err
+      );
+      n_prime = NULL_NODE;
     }
 
     if (DEBUGGING_LOCAL) {
-        console.log("find_successor: departing n'.successor = ", n_prime_successor.id);
-        console.log("^^^^^     ^^^^^     find_successor     ^^^^^     ^^^^^");
+      console.log("find_successor: n' is ", n_prime.id);
     }
 
-    // return n'.successor;
-    return n_prime_successor;
+    // get n'.successor either locally or remotely
+    try {
+      n_prime_successor = await getSuccessor(_self, n_prime);
+    } catch (err) {
+      console.error(`find_successor's call to getSuccessor failed with `, err);
+      n_prime_successor = NULL_NODE;
+    }
+
+    if (DEBUGGING_LOCAL) {
+      console.log("find_successor: n'.successor is ", n_prime_successor.id);
+    }
+  } else {
+    // create client for remote call
+    const node_queried_client = caller(
+      `localhost:${node_queried.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    // now grab the remote value
+    try {
+      n_prime_successor = await node_queried_client.find_successor_remotehelper(
+        { id: id, node: node_queried }
+      );
+    } catch (err) {
+      n_prime_successor = NULL_NODE;
+      console.error(
+        "find_successor call to find_successor_remotehelper failed with",
+        err
+      );
+    }
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "find_successor: departing n'.successor = ",
+      n_prime_successor.id
+    );
+    console.log("^^^^^     ^^^^^     find_successor     ^^^^^     ^^^^^");
+  }
+
+  // return n'.successor;
+  return n_prime_successor;
 }
 
-/** 
+/**
  * RPC equivalent of the pseudocode's find_successor() method.
  * It is implemented as simply a wrapper for the local find_successor() method.
- * 
+ *
  * @param id_and_node_queried {id:, node:}, where ID is the key sought
  * @param callback grpc callback function
- * 
+ *
  */
 async function find_successor_remotehelper(id_and_node_queried, callback) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    const id = id_and_node_queried.request.id;
-    const node_queried = id_and_node_queried.request.node;
+  const id = id_and_node_queried.request.id;
+  const node_queried = id_and_node_queried.request.node;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     find_successor_remotehelper     vvvvv     vvvvv");
-        console.log("id = ", id, "node_queried = ", node_queried.id, ".");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "vvvvv     vvvvv     find_successor_remotehelper     vvvvv     vvvvv"
+    );
+    console.log("id = ", id, "node_queried = ", node_queried.id, ".");
+  }
 
-    let n_prime_successor = NULL_NODE;
-    try {
-        n_prime_successor = await find_successor(id, _self, node_queried);
-    } catch (err) {
-        console.error("n_prime_successor call to find_successor failed with", err);
-        n_prime_successor = NULL_NODE;
-    }
-    callback(null, n_prime_successor);
+  let n_prime_successor = NULL_NODE;
+  try {
+    n_prime_successor = await find_successor(id, _self, node_queried);
+  } catch (err) {
+    console.error("n_prime_successor call to find_successor failed with", err);
+    n_prime_successor = NULL_NODE;
+  }
+  callback(null, n_prime_successor);
 
-    if (DEBUGGING_LOCAL) {
-        console.log("find_successor_remotehelper: n_prime_successor = ", n_prime_successor.id);
-        console.log("^^^^^     ^^^^^     find_successor_remotehelper     ^^^^^     ^^^^^");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "find_successor_remotehelper: n_prime_successor = ",
+      n_prime_successor.id
+    );
+    console.log(
+      "^^^^^     ^^^^^     find_successor_remotehelper     ^^^^^     ^^^^^"
+    );
+  }
 }
 
-/** 
+/**
  * This function directly implements the pseudocode's find_predecessor() method,
  *  with the exception of the limits on the while loop.
- * 
+ *
  * @todo 20191103.hk: re-examine the limits on the while loop
  * @param {number} id the key sought
-*/
+ */
 async function find_predecessor(id) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     find_predecessor     vvvvv     vvvvv");
-        console.log("id = ", id);
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     find_predecessor     vvvvv     vvvvv");
+    console.log("id = ", id);
+  }
 
-    let n_prime = _self;
-    let prior_n_prime = NULL_NODE;
-    let n_prime_successor = NULL_NODE;
-    // n' = n;
+  let n_prime = _self;
+  let prior_n_prime = NULL_NODE;
+  let n_prime_successor = NULL_NODE;
+  // n' = n;
+  try {
+    n_prime_successor = await getSuccessor(_self, n_prime);
+  } catch (err) {
+    console.error("find_predecessor call to getSuccessor failed with", err);
+    n_prime_successor = NULL_NODE;
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "before while: n_prime = ",
+      n_prime.id,
+      "; n_prime_successor = ",
+      n_prime_successor.id
+    );
+  }
+
+  // (maximum chord nodes = 2^m) * (length of finger table = m)
+  let iteration_counter = 2 ** HASH_BIT_LENGTH * HASH_BIT_LENGTH;
+  // while (id 'not-in' (n', n'.successor] )
+  while (
+    !isInModuloRange(id, n_prime.id, false, n_prime_successor.id, true) &&
+    n_prime.id !== n_prime_successor.id &&
+    // && (n_prime.id !== prior_n_prime.id)
+    iteration_counter >= 0
+  ) {
+    // loop should exit if n' and its successor are the same
+    // loop should exit if n' and the prior n' are the same
+    // loop should exit if the iterations are ridiculous
+    // update loop protection
+    iteration_counter--;
+    // n' = n'.closest_preceding_finger(id);
     try {
-        n_prime_successor = await getSuccessor(_self, n_prime);
+      n_prime = await closest_preceding_finger(id, _self, n_prime);
     } catch (err) {
-        console.error("find_predecessor call to getSuccessor failed with", err);
-        n_prime_successor = NULL_NODE;
+      n_prime = NULL_NODE;
     }
 
     if (DEBUGGING_LOCAL) {
-        console.log("before while: n_prime = ", n_prime.id, "; n_prime_successor = ", n_prime_successor.id);
+      console.log("=== while iteration ", iteration_counter, " ===");
+      console.log("n_prime = ", n_prime);
     }
 
-    // (maximum chord nodes = 2^m) * (length of finger table = m)
-    let iteration_counter = 2 ** HASH_BIT_LENGTH * HASH_BIT_LENGTH;
-    // while (id 'not-in' (n', n'.successor] )
-    while (!(isInModuloRange(id, n_prime.id, false, n_prime_successor.id, true))
-        && (n_prime.id !== n_prime_successor.id)
-        // && (n_prime.id !== prior_n_prime.id)
-        && (iteration_counter >= 0)) {
-        // loop should exit if n' and its successor are the same
-        // loop should exit if n' and the prior n' are the same
-        // loop should exit if the iterations are ridiculous
-        // update loop protection
-        iteration_counter--;
-        // n' = n'.closest_preceding_finger(id);
-        try {
-            n_prime = await closest_preceding_finger(id, _self, n_prime);
-        } catch (err) {
-            n_prime = NULL_NODE;
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("=== while iteration ", iteration_counter, " ===");
-            console.log("n_prime = ", n_prime);
-        }
-
-        try {
-            n_prime_successor = await getSuccessor(_self, n_prime);
-        } catch (err) {
-            console.error("find_predecessor call to getSuccessor (2) failed with", err);
-            n_prime_successor = NULL_NODE;
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("n_prime_successor = ", n_prime_successor);
-        }
-
-        // store state
-        prior_n_prime = n_prime;
+    try {
+      n_prime_successor = await getSuccessor(_self, n_prime);
+    } catch (err) {
+      console.error(
+        "find_predecessor call to getSuccessor (2) failed with",
+        err
+      );
+      n_prime_successor = NULL_NODE;
     }
 
     if (DEBUGGING_LOCAL) {
-        console.log("^^^^^     ^^^^^     find_predecessor     ^^^^^     ^^^^^");
+      console.log("n_prime_successor = ", n_prime_successor);
     }
 
-    // return n';
-    return n_prime;
+    // store state
+    prior_n_prime = n_prime;
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log("^^^^^     ^^^^^     find_predecessor     ^^^^^     ^^^^^");
+  }
+
+  // return n';
+  return n_prime;
 }
 
 /**
@@ -330,199 +368,244 @@ async function find_predecessor(id) {
  * @returns : the successor if the successor seems valid, or a null node otherwise
  */
 async function getSuccessor(node_querying, node_queried) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     getSuccessor     vvvvv     vvvvv");
-        console.log("{", node_querying.id, "}.getSuccessor(", node_queried.id, ")");
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     getSuccessor     vvvvv     vvvvv");
+    console.log("{", node_querying.id, "}.getSuccessor(", node_queried.id, ")");
+  }
+
+  // get n.successor either locally or remotely
+  let n_successor = NULL_NODE;
+  if (node_querying.id == node_queried.id) {
+    // use local value
+    n_successor = fingerTable[0].successor;
+  } else {
+    // use remote value
+    // create client for remote call
+    const node_queried_client = caller(
+      `localhost:${node_queried.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    // now grab the remote value
+    try {
+      n_successor = await node_queried_client.getSuccessor_remotehelper(
+        node_queried
+      );
+    } catch (err) {
+      // TBD 20191103.hk: why does "n_successor = NULL_NODE;" not do the same as explicit?!?!
+      n_successor = { id: null, ip: null, port: null };
+      console.trace("Remote error in getSuccessor() ", err);
     }
+  }
 
-    // get n.successor either locally or remotely
-    let n_successor = NULL_NODE;
-    if (node_querying.id == node_queried.id) {
-        // use local value
-        n_successor = fingerTable[0].successor;
-    } else {
-        // use remote value
-        // create client for remote call
-        const node_queried_client = caller(`localhost:${node_queried.port}`, PROTO_PATH, "Node");
-        // now grab the remote value
-        try {
-            n_successor = await node_queried_client.getSuccessor_remotehelper(node_queried);
-        } catch (err) {
-            // TBD 20191103.hk: why does "n_successor = NULL_NODE;" not do the same as explicit?!?!
-            n_successor = {id: null, ip: null, port: null};
-            console.trace("Remote error in getSuccessor() ", err);
-        }
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "returning {",
+      node_queried.id,
+      "}.successor = ",
+      n_successor.id
+    );
+    console.log("^^^^^     ^^^^^     getSuccessor     ^^^^^     ^^^^^");
+  }
 
-    if (DEBUGGING_LOCAL) {
-        console.log("returning {", node_queried.id, "}.successor = ", n_successor.id);
-        console.log("^^^^^     ^^^^^     getSuccessor     ^^^^^     ^^^^^");
-    }
-
-    return n_successor;
+  return n_successor;
 }
 
-/** 
+/**
  * RPC equivalent of the getSuccessor() method.
  * It is implemented as simply a wrapper for the getSuccessor() function.
  * @param _ - dummy parameter
  * @param callback - grpc callback
  */
 async function getSuccessor_remotehelper(_, callback) {
-    callback(null, fingerTable[0].successor);
+  callback(null, fingerTable[0].successor);
 }
 
 /**
  * Directly implement the pseudocode's closest_preceding_finger() method.
- * 
+ *
  * However, it is able to discern whether to do a local lookup or an RPC.
  * If the querying node is the same as the queried node, it will stay local.
- * 
+ *
  * @param id
  * @param node_querying
  * @param node_queried
  * @returns the closest preceding node to ID
- * 
+ *
  */
 async function closest_preceding_finger(id, node_querying, node_queried) {
-    let n_preceding = NULL_NODE;
-    if (node_querying.id == node_queried.id) {
-        // use local value
-        // for i = m downto 1
-        for (let i = HASH_BIT_LENGTH - 1; i >= 0; i--) {
-            // if ( finger[i].node 'is-in' (n, id) )
-            if (isInModuloRange(fingerTable[i].successor.id, node_queried.id, false, id, false)) {
-                // return finger[i].node;
-                n_preceding = fingerTable[i].successor;
-                return n_preceding;
-            }
-        }
-        // return n;
-        n_preceding = node_queried;
+  let n_preceding = NULL_NODE;
+  if (node_querying.id == node_queried.id) {
+    // use local value
+    // for i = m downto 1
+    for (let i = HASH_BIT_LENGTH - 1; i >= 0; i--) {
+      // if ( finger[i].node 'is-in' (n, id) )
+      if (
+        isInModuloRange(
+          fingerTable[i].successor.id,
+          node_queried.id,
+          false,
+          id,
+          false
+        )
+      ) {
+        // return finger[i].node;
+        n_preceding = fingerTable[i].successor;
         return n_preceding;
-    } else {
-        // use remote value
-        // create client for remote call
-        const node_queried_client = caller(`localhost:${node_queried.port}`, PROTO_PATH, "Node");
-        // now grab the remote value
-        try {
-            n_preceding = await node_queried_client.closest_preceding_finger_remotehelper({ id: id, node: node_queried });
-        } catch (err) {
-            n_preceding = NULL_NODE;
-            console.error("closest_preceding_finger call to closest_preceding_finger_remotehelper failed with ", err);
-        }
-        // return n;
-        return n_preceding;
+      }
     }
+    // return n;
+    n_preceding = node_queried;
+    return n_preceding;
+  } else {
+    // use remote value
+    // create client for remote call
+    const node_queried_client = caller(
+      `localhost:${node_queried.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    // now grab the remote value
+    try {
+      n_preceding = await node_queried_client.closest_preceding_finger_remotehelper(
+        { id: id, node: node_queried }
+      );
+    } catch (err) {
+      n_preceding = NULL_NODE;
+      console.error(
+        "closest_preceding_finger call to closest_preceding_finger_remotehelper failed with ",
+        err
+      );
+    }
+    // return n;
+    return n_preceding;
+  }
 }
 
-/** 
+/**
  * RPC equivalent of the pseudocode's closest_preceding_finger() method.
  * It is implemented as simply a wrapper for the local closest_preceding_finger() function.
- * 
+ *
  * @param id_and_node_queried {id:, node:}, where ID is the key sought
  * @param callback - grpc callback
- * 
+ *
  */
-async function closest_preceding_finger_remotehelper(id_and_node_queried, callback) {
-    const id = id_and_node_queried.request.id;
-    const node_queried = id_and_node_queried.request.node;
-    let n_preceding = NULL_NODE;
-    try {
-        n_preceding = await closest_preceding_finger(id, _self, node_queried);
-    } catch (err) {
-        console.error("closest_preceding_finger_remotehelper call to closest_preceding_finger failed with ", err);
-        n_preceding = NULL_NODE;
-    }
-    callback(null, n_preceding);
+async function closest_preceding_finger_remotehelper(
+  id_and_node_queried,
+  callback
+) {
+  const id = id_and_node_queried.request.id;
+  const node_queried = id_and_node_queried.request.node;
+  let n_preceding = NULL_NODE;
+  try {
+    n_preceding = await closest_preceding_finger(id, _self, node_queried);
+  } catch (err) {
+    console.error(
+      "closest_preceding_finger_remotehelper call to closest_preceding_finger failed with ",
+      err
+    );
+    n_preceding = NULL_NODE;
+  }
+  callback(null, n_preceding);
 }
 
 /**
  * RPC to return the node's predecessor.
- * 
+ *
  * @param _ - unused dummy argument
  * @param callback - grpc callback
  * @returns predecessor node
  */
 async function getPredecessor(_, callback) {
-    callback(null, predecessor);
+  callback(null, predecessor);
 }
 
 /**
  * RPC to replace the value of the node's predecessor.
- * 
+ *
  * @param message is a node object
  * @param callback
  */
 async function setPredecessor(message, callback) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     setPredecessor     vvvvv     vvvvv");
-        console.log("Self = ", _self);
-        console.log("Self's original predecessor = ", predecessor);
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     setPredecessor     vvvvv     vvvvv");
+    console.log("Self = ", _self);
+    console.log("Self's original predecessor = ", predecessor);
+  }
 
-    predecessor = message.request; //message.request is node
+  predecessor = message.request; //message.request is node
 
-    if (DEBUGGING_LOCAL) {
-        console.log("Self's new predecessor = ", predecessor);
-        console.log("^^^^^     ^^^^^     setPredecessor     ^^^^^     ^^^^^");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("Self's new predecessor = ", predecessor);
+    console.log("^^^^^     ^^^^^     setPredecessor     ^^^^^     ^^^^^");
+  }
 
-    callback(null, {});
+  callback(null, {});
 }
 
-
 /**
- * Modified implementation of pseudocode's "heavyweight" version of the join() method 
+ * Modified implementation of pseudocode's "heavyweight" version of the join() method
  *   as described in Figure 6 of the SIGCOMM paper.
  * Modification consists of an additional step of initializing the successor table
  *   as described in the IEEE paper.
- * 
+ *
  * @param known_node: known_node structure; e.g., {id, ip, port}
  *   Pass a null known node to force the node to be the first in a new chord.
  */
 async function join(known_node) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
-    // remove dummy template initializer from table
-    fingerTable.pop();
-    // initialize table with reasonable values
-    for (let i = 0; i < HASH_BIT_LENGTH; i++) {
-        fingerTable.push({
-            start: (_self.id + 2 ** i) % (2 ** HASH_BIT_LENGTH),
-            successor: _self
-        });
-    }
-    // if (n')
-    if (known_node && confirm_exist(known_node)) {
-        // (n');
-        await init_finger_table(known_node);
-        // update_others();
-        await update_others();
-    } else {
-        // this is the first node
-        // initialize predecessor
-        predecessor = _self;
-    }
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
+  // remove dummy template initializer from table
+  fingerTable.pop();
+  // initialize table with reasonable values
+  for (let i = 0; i < HASH_BIT_LENGTH; i++) {
+    fingerTable.push({
+      start: (_self.id + 2 ** i) % 2 ** HASH_BIT_LENGTH,
+      successor: _self
+    });
+  }
+  // if (n')
+  if (known_node && confirm_exist(known_node)) {
+    // (n');
+    await init_finger_table(known_node);
+    // update_others();
+    await update_others();
+  } else {
+    // this is the first node
+    // initialize predecessor
+    predecessor = _self;
+  }
 
-    // TODO migrate keys: (predecessor, n]; i.e., (predecessor, _self]
-    await migrate_keys();
+  // TODO migrate keys: (predecessor, n]; i.e., (predecessor, _self]
+  await migrate_keys();
 
-    // initialize successor table - deviates from SIGCOMM
-    successorTable[0] = fingerTable[0].successor;
+  // initialize successor table - deviates from SIGCOMM
+  successorTable[0] = fingerTable[0].successor;
 
-    if (DEBUGGING_LOCAL) {
-        console.log(">>>>>     join          ");
-        console.log("The fingerTable[] leaving {", _self.id, "}.join(", known_node.id, ") is:\n", fingerTable);
-        console.log("The {", _self.id, "}.predecessor leaving join() is ", predecessor);
-        console.log("          join     <<<<<\n");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log(">>>>>     join          ");
+    console.log(
+      "The fingerTable[] leaving {",
+      _self.id,
+      "}.join(",
+      known_node.id,
+      ") is:\n",
+      fingerTable
+    );
+    console.log(
+      "The {",
+      _self.id,
+      "}.predecessor leaving join() is ",
+      predecessor
+    );
+    console.log("          join     <<<<<\n");
+  }
 }
 
 /**
@@ -531,7 +614,7 @@ async function join(known_node) {
  * @returns {boolean}
  */
 function confirm_exist(known_node) {
-    return !(_self.id == known_node.id);
+  return !(_self.id == known_node.id);
 }
 
 /**
@@ -539,293 +622,415 @@ function confirm_exist(known_node) {
  * @param n_prime
  */
 async function init_finger_table(n_prime) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     init_finger_table     vvvvv     vvvvv");
-        console.log("self = ", _self.id, "; self.successor = ", fingerTable[0].successor.id, "; finger[0].start = ", fingerTable[0].start);
-        console.log("n' = ", n_prime.id);
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     init_finger_table     vvvvv     vvvvv");
+    console.log(
+      "self = ",
+      _self.id,
+      "; self.successor = ",
+      fingerTable[0].successor.id,
+      "; finger[0].start = ",
+      fingerTable[0].start
+    );
+    console.log("n' = ", n_prime.id);
+  }
 
-    let n_prime_successor = NULL_NODE;
-    try {
-        n_prime_successor = await find_successor(fingerTable[0].start, _self, n_prime);
-    } catch (err) {
-        n_prime_successor = NULL_NODE;
-        console.error("init_finger_table call to find_successor failed with ", err);
-    }
-    // finger[1].node = n'.find_successor(finger[1].start);
-    fingerTable[0].successor = n_prime_successor;
+  let n_prime_successor = NULL_NODE;
+  try {
+    n_prime_successor = await find_successor(
+      fingerTable[0].start,
+      _self,
+      n_prime
+    );
+  } catch (err) {
+    n_prime_successor = NULL_NODE;
+    console.error("init_finger_table call to find_successor failed with ", err);
+  }
+  // finger[1].node = n'.find_successor(finger[1].start);
+  fingerTable[0].successor = n_prime_successor;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("n'.successor (now  self.successor) = ", n_prime_successor);
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("n'.successor (now  self.successor) = ", n_prime_successor);
+  }
 
-    // client for newly-determined successor
-    let successor_client = caller(`localhost:${fingerTable[0].successor.port}`, PROTO_PATH, "Node");
-    // predecessor = successor.predecessor;
-    try {
-        predecessor = await successor_client.getPredecessor(fingerTable[0].successor);
-    } catch (err) {
-        predecessor = NULL_NODE;
-        console.error("init_finger_table call to getPredecessor failed with", err);
-    }
-    // successor.predecessor = n;
-    try {
-        await successor_client.setPredecessor(_self);
-    } catch (err) {
-        console.error("init_finger_table call to setPredecessor() failed with ", err);
-    }
+  // client for newly-determined successor
+  let successor_client = caller(
+    `localhost:${fingerTable[0].successor.port}`,
+    PROTO_PATH,
+    "Node"
+  );
+  // predecessor = successor.predecessor;
+  try {
+    predecessor = await successor_client.getPredecessor(
+      fingerTable[0].successor
+    );
+  } catch (err) {
+    predecessor = NULL_NODE;
+    console.error("init_finger_table call to getPredecessor failed with", err);
+  }
+  // successor.predecessor = n;
+  try {
+    await successor_client.setPredecessor(_self);
+  } catch (err) {
+    console.error(
+      "init_finger_table call to setPredecessor() failed with ",
+      err
+    );
+  }
 
-    if (DEBUGGING_LOCAL) {
-        console.log("init_finger_table: predecessor  ", predecessor);
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log("init_finger_table: predecessor  ", predecessor);
+  }
 
-    // for (i=1 to m-1){}, where 1 is really 0, and skip last element
-    for (let i = 0; i < HASH_BIT_LENGTH - 1; i++) {
-        // if ( finger[i+1].start 'is in' [n, finger[i].node) )
-        if (isInModuloRange(fingerTable[i + 1].start, _self.id, true, fingerTable[i].successor.id, false)) {
-            // finger[i+1].node = finger[i].node;
-            fingerTable[i + 1].successor = fingerTable[i].successor;
-        } else {
-            // finger[i+1].node = n'.find_successor(finger[i+1].start);
-            try {
-                fingerTable[i + 1].successor = await find_successor(fingerTable[i + 1].start, _self, n_prime);
-            } catch (err) {
-                fingerTable[i + 1].successor = NULL_NODE;
-                console.error("init_finger_table call to find_successor() failed with ", err);
-            }
-        }
+  // for (i=1 to m-1){}, where 1 is really 0, and skip last element
+  for (let i = 0; i < HASH_BIT_LENGTH - 1; i++) {
+    // if ( finger[i+1].start 'is in' [n, finger[i].node) )
+    if (
+      isInModuloRange(
+        fingerTable[i + 1].start,
+        _self.id,
+        true,
+        fingerTable[i].successor.id,
+        false
+      )
+    ) {
+      // finger[i+1].node = finger[i].node;
+      fingerTable[i + 1].successor = fingerTable[i].successor;
+    } else {
+      // finger[i+1].node = n'.find_successor(finger[i+1].start);
+      try {
+        fingerTable[i + 1].successor = await find_successor(
+          fingerTable[i + 1].start,
+          _self,
+          n_prime
+        );
+      } catch (err) {
+        fingerTable[i + 1].successor = NULL_NODE;
+        console.error(
+          "init_finger_table call to find_successor() failed with ",
+          err
+        );
+      }
     }
-    if (DEBUGGING_LOCAL) {
-        console.log("init_finger_table: fingerTable[] =\n", fingerTable);
-        console.log("^^^^^     ^^^^^     init_finger_table     ^^^^^     ^^^^^");
-    }
+  }
+  if (DEBUGGING_LOCAL) {
+    console.log("init_finger_table: fingerTable[] =\n", fingerTable);
+    console.log("^^^^^     ^^^^^     init_finger_table     ^^^^^     ^^^^^");
+  }
 }
 
 /**
  * Directly implement the pseudocode's update_others() method.
- * 
+ *
  */
 async function update_others() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     update_others     vvvvv     vvvvv");
-        console.log("_self = ", _self);
-    }
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     update_others     vvvvv     vvvvv");
+    console.log("_self = ", _self);
+  }
 
-    let p_node = NULL_NODE;
-    let p_node_search_id;
-    let p_node_client;
-    // for i = 1 to m
-    for (let i = 0; i < HASH_BIT_LENGTH; i++) {
-        /* argument for "p = find_predecessor(n - 2^(i - 1))"
+  let p_node = NULL_NODE;
+  let p_node_search_id;
+  let p_node_client;
+  // for i = 1 to m
+  for (let i = 0; i < HASH_BIT_LENGTH; i++) {
+    /* argument for "p = find_predecessor(n - 2^(i - 1))"
             but really 2^(i) because the index is now 0-based
             nonetheless, avoid ambiguity with negative numbers by:
                 1- pegging 0 to 2^m with "+ 2**HASH_BIT_LENGTH
                 2- taking the mod with "% 2**HASH_BIT_LENGTH"
         */
-        p_node_search_id = (_self.id - 2 ** i + 2 ** HASH_BIT_LENGTH) % (2 ** HASH_BIT_LENGTH);
-        if (DEBUGGING_LOCAL) {
-            console.log("i = ", i, "; find_predecessor(", p_node_search_id, ") --> p_node");
-        }
+    p_node_search_id =
+      (_self.id - 2 ** i + 2 ** HASH_BIT_LENGTH) % 2 ** HASH_BIT_LENGTH;
+    if (DEBUGGING_LOCAL) {
+      console.log(
+        "i = ",
+        i,
+        "; find_predecessor(",
+        p_node_search_id,
+        ") --> p_node"
+      );
+    }
 
-        // p = find_predecessor(n - 2^(i - 1));
-        try {
-            p_node = await find_predecessor(p_node_search_id);
-        } catch (err) {
-            p_node = NULL_NODE;
-            console.error("Error from find_predecessor(", p_node_search_id, ") in update_others().", err);
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("p_node = ", p_node);
-        }
-
-        // p.update_finger_table(n, i);
-        if (_self.id !== p_node.id) {
-            p_node_client = caller(`localhost:${p_node.port}`, PROTO_PATH, "Node");
-            try {
-                await p_node_client.update_finger_table({ node: _self, index: i });
-            } catch (err) {
-                console.error("update_others: client.update_finger_table error ", err);
-            }
-        }
+    // p = find_predecessor(n - 2^(i - 1));
+    try {
+      p_node = await find_predecessor(p_node_search_id);
+    } catch (err) {
+      p_node = NULL_NODE;
+      console.error(
+        "Error from find_predecessor(",
+        p_node_search_id,
+        ") in update_others().",
+        err
+      );
     }
 
     if (DEBUGGING_LOCAL) {
-        console.log("^^^^^     ^^^^^     update_others     ^^^^^     ^^^^^");
+      console.log("p_node = ", p_node);
     }
+
+    // p.update_finger_table(n, i);
+    if (_self.id !== p_node.id) {
+      p_node_client = caller(`localhost:${p_node.port}`, PROTO_PATH, "Node");
+      try {
+        await p_node_client.update_finger_table({ node: _self, index: i });
+      } catch (err) {
+        console.error("update_others: client.update_finger_table error ", err);
+      }
+    }
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log("^^^^^     ^^^^^     update_others     ^^^^^     ^^^^^");
+  }
 }
 
 /**
  * RPC that directly implements the pseudocode's update_finger_table() method.
- * 
- * @param message - consists of {s_node, finger_index} * 
+ *
+ * @param message - consists of {s_node, finger_index} *
  * @param callback - grpc callback
  */
 async function update_finger_table(message, callback) {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    const s_node = message.request.node;
-    const finger_index = message.request.index;
+  const s_node = message.request.node;
+  const finger_index = message.request.index;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     update_finger_table     vvvvv     vvvvv");
-        console.log("{", _self.id, "}.fingerTable[] =\n", fingerTable);
-        console.log("s_node = ", message.request.node.id, "; finger_index =", finger_index);
+  if (DEBUGGING_LOCAL) {
+    console.log("vvvvv     vvvvv     update_finger_table     vvvvv     vvvvv");
+    console.log("{", _self.id, "}.fingerTable[] =\n", fingerTable);
+    console.log(
+      "s_node = ",
+      message.request.node.id,
+      "; finger_index =",
+      finger_index
+    );
+  }
+
+  // if ( s 'is in' [n, finger[i].node) )
+  if (
+    isInModuloRange(
+      s_node.id,
+      _self.id,
+      true,
+      fingerTable[finger_index].successor.id,
+      false
+    )
+  ) {
+    // finger[i].node = s;
+    fingerTable[finger_index].successor = s_node;
+    // p = predecessor;
+    const p_client = caller(
+      `localhost:${predecessor.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    // p.update_finger_table(s, i);
+    try {
+      await p_client.update_finger_table({ node: s_node, index: finger_index });
+    } catch (err) {
+      console.error(
+        "Error updating the finger table of {",
+        s_node.id,
+        "}.\n\n",
+        err
+      );
     }
 
-    // if ( s 'is in' [n, finger[i].node) )
-    if (isInModuloRange(s_node.id, _self.id, true, fingerTable[finger_index].successor.id, false)) {
-        // finger[i].node = s;
-        fingerTable[finger_index].successor = s_node;
-        // p = predecessor;
-        const p_client = caller(`localhost:${predecessor.port}`, PROTO_PATH, "Node");
-        // p.update_finger_table(s, i);
-        try {
-            await p_client.update_finger_table({ node: s_node, index: finger_index });
-        } catch (err) {
-            console.error("Error updating the finger table of {", s_node.id, "}.\n\n", err);
-        }
-
-        if (DEBUGGING_LOCAL) {
-            console.log("Updated {", _self.id, "}.fingerTable[", finger_index, "] to ", s_node);
-            console.log("^^^^^     ^^^^^     update_finger_table     ^^^^^     ^^^^^");
-        }
-
-        // TODO: Figure out how to determine if the above had an RC of 0
-        // If so call callback({status: 0, message: "OK"}, {});
-        callback(null, {});
-        return;
-    }
-
     if (DEBUGGING_LOCAL) {
-        console.log("^^^^^     ^^^^^     update_finger_table     ^^^^^     ^^^^^");
+      console.log(
+        "Updated {",
+        _self.id,
+        "}.fingerTable[",
+        finger_index,
+        "] to ",
+        s_node
+      );
+      console.log(
+        "^^^^^     ^^^^^     update_finger_table     ^^^^^     ^^^^^"
+      );
     }
 
     // TODO: Figure out how to determine if the above had an RC of 0
-    //callback({ status: 0, message: "OK" }, {});
+    // If so call callback({status: 0, message: "OK"}, {});
     callback(null, {});
+    return;
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log("^^^^^     ^^^^^     update_finger_table     ^^^^^     ^^^^^");
+  }
+
+  // TODO: Figure out how to determine if the above had an RC of 0
+  //callback({ status: 0, message: "OK" }, {});
+  callback(null, {});
 }
 
 /**
  * Update fault-tolerance structure discussed in E.3 'Failure and Replication' of IEEE paper.
- * 
- * "Node reconciles its list with its successor by: 
- *      [1-] copying successor's successor list, 
- *      [2-] removing its last entry, 
+ *
+ * "Node reconciles its list with its successor by:
+ *      [1-] copying successor's successor list,
+ *      [2-] removing its last entry,
  *      [3-] and prepending to it.
- * If node notices that its successor has failed, 
- *      [1-] it replaces it with the first live entry in its successor list 
+ * If node notices that its successor has failed,
+ *      [1-] it replaces it with the first live entry in its successor list
  *      [2-] and reconciles its successor list with its new successor."
- * 
+ *
  * @returns {boolean} true if it was successful; false otherwise.
- * 
+ *
  */
 async function update_successor_table() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
-    if (DEBUGGING_LOCAL) {
-        console.log("vvvvv     vvvvv     update_successor_table     vvvvv     vvvvv");
-        console.log("{", _self.id, "}.successorTable[] =\n", successorTable);
-        console.log("s_node = ", fingerTable[0].successor.id);
-    }
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "vvvvv     vvvvv     update_successor_table     vvvvv     vvvvv"
+    );
+    console.log("{", _self.id, "}.successorTable[] =\n", successorTable);
+    console.log("s_node = ", fingerTable[0].successor.id);
+  }
 
-    // check whether the successor is available
-    let successor_seems_ok = false;
-    try {
+  // check whether the successor is available
+  let successor_seems_ok = false;
+  try {
+    successor_seems_ok = await check_successor();
+  } catch (err) {
+    console.error(
+      `update_successor_table call to check_successor failed with `,
+      err
+    );
+    successor_seems_ok = false;
+  }
+  if (successor_seems_ok) {
+    // synchronize immediate successor if it is valid
+    successorTable[0] = fingerTable[0].successor;
+  } else {
+    // or prune if the successor is not valid
+    while (!successor_seems_ok && successorTable.length > 0) {
+      // try current successor again to account for contention or bad luck
+      try {
         successor_seems_ok = await check_successor();
-    } catch (err) {
-        console.error(`update_successor_table call to check_successor failed with `, err);
+      } catch (err) {
+        console.error(
+          `update_successor_table call to check_successor failed with `,
+          err
+        );
         successor_seems_ok = false;
-    }
-    if (successor_seems_ok) {
+      }
+      if (successor_seems_ok) {
         // synchronize immediate successor if it is valid
         successorTable[0] = fingerTable[0].successor;
-    } else {
-        // or prune if the successor is not valid
-        while ((!successor_seems_ok) && (successorTable.length > 0)) {
-            // try current successor again to account for contention or bad luck
-            try {
-                successor_seems_ok = await check_successor();
-            } catch (err) {
-                console.error(`update_successor_table call to check_successor failed with `, err);
-                successor_seems_ok = false;
-            }
-            if (successor_seems_ok) {
-                // synchronize immediate successor if it is valid
-                successorTable[0] = fingerTable[0].successor;
-            } else {
-                // drop the first successor candidate
-                successorTable.shift();
-                // update the finger table to the next candidate
-                fingerTable[0].successor = successorTable[0];
-            }
-        }
+      } else {
+        // drop the first successor candidate
+        successorTable.shift();
+        // update the finger table to the next candidate
+        fingerTable[0].successor = successorTable[0];
+      }
     }
-    if (successorTable.length < 1) {
-        // this node is isolated
-        successorTable.push({id: _self.id, ip: _self.ip, port: _self.port});
-    }
-    // try to bulk up the table
-    let successor_successor = NULL_NODE;
-    if ((successorTable.length < HASH_BIT_LENGTH) && 
-        (_self.id !== fingerTable[0].successor)) {
-        if (DEBUGGING_LOCAL) {
-            console.log("Short successorTable[]: prefer length ", HASH_BIT_LENGTH,
-                " but actual length is ", successorTable.length, ".");
-        }
-        for (let i = 0; (i < successorTable.length) && (i <= HASH_BIT_LENGTH); i++) {
-            try {
-                successor_successor = await getSuccessor(_self, successorTable[i]);
-            } catch (err) {
-                console.error(`update_successor_table call to getSuccessor failed with `, err);
-                successor_successor = {id: null, ip: null, port: null};
-            }
-            if (DEBUGGING_LOCAL) {
-                console.log("{", _self.id, "}.st[", i, "] = ", successorTable[i].id, 
-                    "; {", successorTable[i].id, "}.successor[0] = ", successor_successor.id);
-            }
-            if ((successor_successor.id !== null) && 
-                !isInModuloRange(successor_successor.id, _self.id, true, successorTable[i].id, true)) {
-                // append the additional value
-                successorTable.splice(i + 1, 1, successor_successor);
-                successor_seems_ok = true;
-            }
-        }
-    }
-    // prune from the bottom
-    let i = successorTable.length - 1;
-    successor_seems_ok = false
-    successor_successor = {id: null, ip: null, port: null};
-    while (((!successor_seems_ok) || (successorTable.length > HASH_BIT_LENGTH)) && (i > 0)) {
-        try {
-            successor_successor = await getSuccessor(_self, successorTable[i]);
-            if (successor_successor.id !== null) {
-                successor_seems_ok = true;
-            }
-        } catch (err) {
-            console.error(`update_successor_table call to getSuccessor failed with `, err);
-            successor_seems_ok = false;
-            successor_successor = NULL_NODE;
-        }
-        if ((!successor_seems_ok) || (i >= HASH_BIT_LENGTH)) {
-            // remove successor candidate
-            successorTable.pop();
-        }
-        i -= 1;
-    }
-
+  }
+  if (successorTable.length < 1) {
+    // this node is isolated
+    successorTable.push({ id: _self.id, ip: _self.ip, port: _self.port });
+  }
+  // try to bulk up the table
+  let successor_successor = NULL_NODE;
+  if (
+    successorTable.length < HASH_BIT_LENGTH &&
+    _self.id !== fingerTable[0].successor
+  ) {
     if (DEBUGGING_LOCAL) {
-        console.log("New {", _self.id, "}.successorTable[] =\n", successorTable);
-        console.log("^^^^^     ^^^^^     update_successor_table     ^^^^^     ^^^^^");
+      console.log(
+        "Short successorTable[]: prefer length ",
+        HASH_BIT_LENGTH,
+        " but actual length is ",
+        successorTable.length,
+        "."
+      );
     }
+    for (let i = 0; i < successorTable.length && i <= HASH_BIT_LENGTH; i++) {
+      try {
+        successor_successor = await getSuccessor(_self, successorTable[i]);
+      } catch (err) {
+        console.error(
+          `update_successor_table call to getSuccessor failed with `,
+          err
+        );
+        successor_successor = { id: null, ip: null, port: null };
+      }
+      if (DEBUGGING_LOCAL) {
+        console.log(
+          "{",
+          _self.id,
+          "}.st[",
+          i,
+          "] = ",
+          successorTable[i].id,
+          "; {",
+          successorTable[i].id,
+          "}.successor[0] = ",
+          successor_successor.id
+        );
+      }
+      if (
+        successor_successor.id !== null &&
+        !isInModuloRange(
+          successor_successor.id,
+          _self.id,
+          true,
+          successorTable[i].id,
+          true
+        )
+      ) {
+        // append the additional value
+        successorTable.splice(i + 1, 1, successor_successor);
+        successor_seems_ok = true;
+      }
+    }
+  }
+  // prune from the bottom
+  let i = successorTable.length - 1;
+  successor_seems_ok = false;
+  successor_successor = { id: null, ip: null, port: null };
+  while (
+    (!successor_seems_ok || successorTable.length > HASH_BIT_LENGTH) &&
+    i > 0
+  ) {
+    try {
+      successor_successor = await getSuccessor(_self, successorTable[i]);
+      if (successor_successor.id !== null) {
+        successor_seems_ok = true;
+      }
+    } catch (err) {
+      console.error(
+        `update_successor_table call to getSuccessor failed with `,
+        err
+      );
+      successor_seems_ok = false;
+      successor_successor = NULL_NODE;
+    }
+    if (!successor_seems_ok || i >= HASH_BIT_LENGTH) {
+      // remove successor candidate
+      successorTable.pop();
+    }
+    i -= 1;
+  }
 
-    return successor_seems_ok;
+  if (DEBUGGING_LOCAL) {
+    console.log("New {", _self.id, "}.successorTable[] =\n", successorTable);
+    console.log(
+      "^^^^^     ^^^^^     update_successor_table     ^^^^^     ^^^^^"
+    );
+  }
+
+  return successor_seems_ok;
 }
 
 /**
@@ -838,104 +1043,137 @@ async function update_successor_table() {
  *  @returns {boolean}
  */
 async function stabilize() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = true;
-    let successor_client;
+  // enable debugging output
+  const DEBUGGING_LOCAL = true;
+  let successor_client;
 
-    let x;
+  let x;
+  try {
+    successor_client = caller(
+      `localhost:${fingerTable[0].successor.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+  } catch {
+    console.error(`stabilize call to caller failed with `, err);
+    return false;
+  }
+  // x = successor.predecessor;
+  if (fingerTable[0].successor.id == _self.id) {
+    // use local value
+    await stabilize_self();
+    x = _self;
+  } else {
+    // use remote value
     try {
-        successor_client = caller(`localhost:${fingerTable[0].successor.port}`, PROTO_PATH, "Node");
-    } catch {
-        console.error(`stabilize call to caller failed with `, err);
-        return false;
-    }
-    // x = successor.predecessor;
-    if (fingerTable[0].successor.id == _self.id) {
-        // use local value
-        await stabilize_self();
-        x = _self;
-    } else {
-        // use remote value
-        try {
-            x = await successor_client.getPredecessor(fingerTable[0].successor);
-        } catch (err) {
-            x = _self;
-            console.log("Warning! \"successor.predecessor\" (i.e., {", 
-                fingerTable[0].successor.id, "}.predecessor), failed in stabilize({", _self.id, "}).");
-        }
-    }
-
-    // if (x 'is in' (n, n.successor))
-    if (isInModuloRange(x.id, _self.id, false, fingerTable[0].successor.id, false)) {
-        // successor = x;
-        fingerTable[0].successor = x;
-    }
-
-    if (DEBUGGING_LOCAL) {
-        console.log(">>>>>     stabilize          ");
-        console.log("{", _self.id, "}.predecessor leaving stabilize() is ", predecessor);
-        console.log("{", _self.id, "}.fingerTable[] is:\n", fingerTable);
-        console.log("{", _self.id, "}.successorTable[] is \n", successorTable);
-        console.log("          stabilize     <<<<<");
-    }
-
-    // successor.notify(n);
-    if (_self.id !== fingerTable[0].successor.id) {
-        successor_client = caller(`localhost:${fingerTable[0].successor.port}`, PROTO_PATH, "Node");
-        try {
-            await successor_client.notify(_self);
-        } catch (err) {
-            console.error(`stabilize call to successor_client.notify failed with `, err);
-        }
-    }
-
-    /* TBD 20191103 */
-    // update successor table - deviates from SIGCOMM
-    try {
-        await update_successor_table();
+      x = await successor_client.getPredecessor(fingerTable[0].successor);
     } catch (err) {
-        console.error(`stabilize call to update_successor_table failed with `, err);
+      x = _self;
+      console.log(
+        'Warning! "successor.predecessor" (i.e., {',
+        fingerTable[0].successor.id,
+        "}.predecessor), failed in stabilize({",
+        _self.id,
+        "})."
+      );
     }
-    /* TBD 20191103 */
-    return true;
+  }
+
+  // if (x 'is in' (n, n.successor))
+  if (
+    isInModuloRange(x.id, _self.id, false, fingerTable[0].successor.id, false)
+  ) {
+    // successor = x;
+    fingerTable[0].successor = x;
+  }
+
+  if (DEBUGGING_LOCAL) {
+    console.log(">>>>>     stabilize          ");
+    console.log(
+      "{",
+      _self.id,
+      "}.predecessor leaving stabilize() is ",
+      predecessor
+    );
+    console.log("{", _self.id, "}.fingerTable[] is:\n", fingerTable);
+    console.log("{", _self.id, "}.successorTable[] is \n", successorTable);
+    console.log("          stabilize     <<<<<");
+  }
+
+  // successor.notify(n);
+  if (_self.id !== fingerTable[0].successor.id) {
+    successor_client = caller(
+      `localhost:${fingerTable[0].successor.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    try {
+      await successor_client.notify(_self);
+    } catch (err) {
+      console.error(
+        `stabilize call to successor_client.notify failed with `,
+        err
+      );
+    }
+  }
+
+  /* TBD 20191103 */
+  // update successor table - deviates from SIGCOMM
+  try {
+    await update_successor_table();
+  } catch (err) {
+    console.error(`stabilize call to update_successor_table failed with `, err);
+  }
+  /* TBD 20191103 */
+  return true;
 }
 
 /**
  * Attempts to kick a node with a successor of self, as would be the case in the first node in a chord.
  * The kick comes from setting the successor to be equal to the predecessor.
- * 
+ *
  * This is an original function, not described in either version of the paper - added 20191021.
  *
  * @returns {boolean} true if it was a good kick; false if bad kick.
-*/
+ */
 async function stabilize_self() {
-    let predecessor_seems_ok = false;
-    if (predecessor.id == null) {
-        // this node is in real trouble since its predecessor is no good either
-        // TODO try to rescue it by stepping through the rest of its finger table, else destroy it
-        predecessor_seems_ok = false;
-        return predecessor_seems_ok;
-    }
-    if (predecessor.id !== _self.id) {
-        try {
-            // confirm that the predecessor is actually there
-            predecessor_seems_ok = await check_predecessor();
-        } catch (err) {
-            predecessor_seems_ok = false;
-            console.error(`stabilize_self call to check_predecessor failed with `, err);
-        }
-        if (predecessor_seems_ok) {
-            // then kick by setting the successor to the same as the predecessor
-            fingerTable[0].successor = predecessor;
-            successorTable[0] = fingerTable[0].successor;
-        }
-    } else {
-        console.log("\nWarning: {", _self.id, "} is isolated because",
-            "predecessor is", predecessor.id,
-            "and successor is", fingerTable[0].successor.id, ".");
-            predecessor_seems_ok = true;
-    }
+  let predecessor_seems_ok = false;
+  if (predecessor.id == null) {
+    // this node is in real trouble since its predecessor is no good either
+    // TODO try to rescue it by stepping through the rest of its finger table, else destroy it
+    predecessor_seems_ok = false;
     return predecessor_seems_ok;
+  }
+  if (predecessor.id !== _self.id) {
+    try {
+      // confirm that the predecessor is actually there
+      predecessor_seems_ok = await check_predecessor();
+    } catch (err) {
+      predecessor_seems_ok = false;
+      console.error(
+        `stabilize_self call to check_predecessor failed with `,
+        err
+      );
+    }
+    if (predecessor_seems_ok) {
+      // then kick by setting the successor to the same as the predecessor
+      fingerTable[0].successor = predecessor;
+      successorTable[0] = fingerTable[0].successor;
+    }
+  } else {
+    console.log(
+      "\nWarning: {",
+      _self.id,
+      "} is isolated because",
+      "predecessor is",
+      predecessor.id,
+      "and successor is",
+      fingerTable[0].successor.id,
+      "."
+    );
+    predecessor_seems_ok = true;
+  }
+  return predecessor_seems_ok;
 }
 
 /**
@@ -944,105 +1182,144 @@ async function stabilize_self() {
  * @param callback the gRPC callback
  */
 async function notify(message, callback) {
-    const n_prime = message.request;
-    // if (predecessor is nil or n' 'is in' (predecessor, n))
-    if ((predecessor.id == null)
-        || isInModuloRange(n_prime.id, predecessor.id, false, _self.id, false)) {
-        // predecessor = n';
-        predecessor = n_prime;
-    }
-    callback(null, {});
+  const n_prime = message.request;
+  // if (predecessor is nil or n' 'is in' (predecessor, n))
+  if (
+    predecessor.id == null ||
+    isInModuloRange(n_prime.id, predecessor.id, false, _self.id, false)
+  ) {
+    // predecessor = n';
+    predecessor = n_prime;
+  }
+  callback(null, {});
 }
 
 /**
  * Directly implements the pseudocode's fix_fingers() method.
- * 
+ *
  */
 async function fix_fingers() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
-    let n_successor = NULL_NODE;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
+  let n_successor = NULL_NODE;
 
-    // i = random index > 1 into finger[]; but really >0 because 0-based
-    // random integer within the range (0, m)
-    const i = Math.ceil(Math.random() * (HASH_BIT_LENGTH - 1));
-    // finger[i].node = find_successor(finger[i].start);
-    try {
-        n_successor = await find_successor(fingerTable[i].start, _self, _self);
-        if (n_successor.id !== null) {
-            fingerTable[i].successor = n_successor;
-        }
-    } catch (err) {
-        console.error(`fix_fingers call to find_successor failed with `, err);
+  // i = random index > 1 into finger[]; but really >0 because 0-based
+  // random integer within the range (0, m)
+  const i = Math.ceil(Math.random() * (HASH_BIT_LENGTH - 1));
+  // finger[i].node = find_successor(finger[i].start);
+  try {
+    n_successor = await find_successor(fingerTable[i].start, _self, _self);
+    if (n_successor.id !== null) {
+      fingerTable[i].successor = n_successor;
     }
-    if (DEBUGGING_LOCAL) {
-        console.log("\n>>>>>     Fix {", _self.id, "}.fingerTable[", i, "], with start = ", fingerTable[i].start, ".");
-        console.log("     fingerTable[", i, "] =", fingerTable[i].successor, "     <<<<<\n");
-    }
+  } catch (err) {
+    console.error(`fix_fingers call to find_successor failed with `, err);
+  }
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "\n>>>>>     Fix {",
+      _self.id,
+      "}.fingerTable[",
+      i,
+      "], with start = ",
+      fingerTable[i].start,
+      "."
+    );
+    console.log(
+      "     fingerTable[",
+      i,
+      "] =",
+      fingerTable[i].successor,
+      "     <<<<<\n"
+    );
+  }
 }
 
 /**
  * Directly implements the check_predecessor() method from the IEEE version of the paper.
- * 
+ *
  * @returns {boolean} true if predecessor was still reasonable; false otherwise.
  */
 async function check_predecessor() {
-    if ((predecessor.id !== null) && (predecessor.id !== _self.id)) {
-        const predecessor_client = caller(`localhost:${predecessor.port}`, PROTO_PATH, "Node");
-        try {
-            // just ask anything
-            const x = await predecessor_client.getPredecessor(_self.id);
-        } catch (err) {
-            console.error(`check_predecessor call to getPredecessor failed with `, err);
-            predecessor = { id: null, ip: null, port: null };
-            return false;
-        }
+  if (predecessor.id !== null && predecessor.id !== _self.id) {
+    const predecessor_client = caller(
+      `localhost:${predecessor.port}`,
+      PROTO_PATH,
+      "Node"
+    );
+    try {
+      // just ask anything
+      const x = await predecessor_client.getPredecessor(_self.id);
+    } catch (err) {
+      console.error(
+        `check_predecessor call to getPredecessor failed with `,
+        err
+      );
+      predecessor = { id: null, ip: null, port: null };
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
 /**
  * Checks whether the successor is still responding.
- * 
+ *
  * This is an original function, not described in either version of the paper - added 20191103.
- * 
+ *
  * @returns {boolean} true if successor was still reasonable; false otherwise.
  */
 async function check_successor() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = false;
+  // enable debugging output
+  const DEBUGGING_LOCAL = false;
 
-    if (DEBUGGING_LOCAL) {
-        console.log("{", _self.id, "}.check_successor(", fingerTable[0].successor.id, ")");
-    }
+  if (DEBUGGING_LOCAL) {
+    console.log(
+      "{",
+      _self.id,
+      "}.check_successor(",
+      fingerTable[0].successor.id,
+      ")"
+    );
+  }
 
-    let n_successor = NULL_NODE;
-    let successor_seems_ok = false;
-    if (fingerTable[0].successor.id == null) {
+  let n_successor = NULL_NODE;
+  let successor_seems_ok = false;
+  if (fingerTable[0].successor.id == null) {
+    successor_seems_ok = false;
+  } else if (fingerTable[0].successor.id == _self.id) {
+    successor_seems_ok = true;
+  } else {
+    try {
+      // just ask anything
+      n_successor = await getSuccessor(_self, fingerTable[0].successor);
+      if (n_successor.id == null) {
         successor_seems_ok = false;
-    } else if (fingerTable[0].successor.id == _self.id) {
+      } else {
+        console.log(
+          "{",
+          fingerTable[0].successor.id,
+          "}.successor =",
+          n_successor.id
+        );
         successor_seems_ok = true;
-    } else {
-        try {
-            // just ask anything
-            n_successor = await getSuccessor(_self, fingerTable[0].successor);
-            if (n_successor.id == null) {
-                successor_seems_ok = false;
-            } else {
-                console.log("{", fingerTable[0].successor.id, "}.successor =", n_successor.id);
-                successor_seems_ok = true;
-            }
-        } catch (err) {
-            successor_seems_ok = false;
-            console.log("Error in check_successor({", _self.id, "}) call to getSuccessor", err);
-        }
+      }
+    } catch (err) {
+      successor_seems_ok = false;
+      console.log(
+        "Error in check_successor({",
+        _self.id,
+        "}) call to getSuccessor",
+        err
+      );
     }
-    return successor_seems_ok;
+  }
+  return successor_seems_ok;
 }
 
 /**
  * Placeholder for data migration within the join() call.
- * 
+ *
  */
 async function migrate_keys() {}
 
@@ -1061,61 +1338,74 @@ async function migrate_keys() {}
  *
  */
 async function main() {
-    // enable debugging output
-    const DEBUGGING_LOCAL = true;
+  // enable debugging output
+  const DEBUGGING_LOCAL = true;
 
-    const args = minimist(process.argv.slice(2));
-    _self.id = args.id ? args.id : 0;
-    _self.ip = args.ip ? args.ip : `0.0.0.0`;
-    _self.port = args.port ? args.port : 1337;
+  const args = minimist(process.argv.slice(2));
+  _self.id = args.id ? args.id : 0;
+  _self.ip = args.ip ? args.ip : `0.0.0.0`;
+  _self.port = args.port ? args.port : 1337;
 
-    if (args.targetIp !== null && 
-        args.targetPort !== null && 
-        args.targetId !== null) {
-        await join({ id: args.targetId, ip: args.targetIp, port: args.targetPort });
-    } else {
-        await join(null);
-    }
+  if (
+    args.targetIp !== null &&
+    args.targetPort !== null &&
+    args.targetId !== null
+  ) {
+    await join({ id: args.targetId, ip: args.targetIp, port: args.targetPort });
+  } else {
+    await join(null);
+  }
 
-    // periodically run stabilization functions
-    setInterval(async () => { await stabilize() }, 3000);
-    setInterval(async () => { await fix_fingers() }, 3000);
-    setInterval(async () => { await check_predecessor() }, CHECK_NODE_TIMEOUT_ms);
+  // periodically run stabilization functions
+  setInterval(async () => {
+    await stabilize();
+  }, 3000);
+  setInterval(async () => {
+    await fix_fingers();
+  }, 3000);
+  setInterval(async () => {
+    await check_predecessor();
+  }, CHECK_NODE_TIMEOUT_ms);
 
-    // server instantiation
-    const server = new grpc.Server();
-    server.addService(chord.Node.service, {
-        summary,
-        fetch,
-        insert,
-        find_successor_remotehelper,
-        getSuccessor_remotehelper,
-        getPredecessor,
-        setPredecessor,
-        closest_preceding_finger_remotehelper,
-        update_finger_table,
-        notify
-    });
-    server.bind(`${_self.ip}:${_self.port}`, grpc.ServerCredentials.createInsecure());
-    server.start();
-    if (DEBUGGING_LOCAL) {
-        console.log(`Serving on ${_self.ip}:${_self.port}`);
-    }
+  // server instantiation
+  const server = new grpc.Server();
+  server.addService(chord.Node.service, {
+    summary,
+    fetch,
+    insert,
+    find_successor_remotehelper,
+    getSuccessor_remotehelper,
+    getPredecessor,
+    setPredecessor,
+    closest_preceding_finger_remotehelper,
+    update_finger_table,
+    notify
+  });
+  server.bind(
+    `${_self.ip}:${_self.port}`,
+    grpc.ServerCredentials.createInsecure()
+  );
+  server.start();
+  if (DEBUGGING_LOCAL) {
+    console.log(`Serving on ${_self.ip}:${_self.port}`);
+  }
 }
 
 /**
  * Creates a worker thread to execute crypto and returns a result.
  * To use `const result = await sha1("stuff2");`
- * @param {string} source 
+ * @param {string} source
  * @returns {Promise} - Resolves to the SHA-1 hash of source
  */
 function sha1(source) {
-    return new Promise((resolve, reject) => {
-        const worker = new Worker(path.join(__dirname, "./cryptoThread.js"), { workerData: source });
-        worker.on("message", resolve);
-        worker.on("error", reject);
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(path.join(__dirname, "./cryptoThread.js"), {
+      workerData: source
     });
-};
+    worker.on("message", resolve);
+    worker.on("error", reject);
+  });
+}
 
 // Example of using the thread
 // async function test(){
@@ -1125,6 +1415,5 @@ function sha1(source) {
 //     console.log("Result is: ", result);
 // };
 // test();
-
 
 main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@grpc/proto-loader": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
@@ -81,10 +101,22 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
       "integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A=="
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -100,10 +132,46 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
     },
     "ascli": {
       "version": "1.0.1",
@@ -118,6 +186,12 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -134,6 +208,16 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "bytebuffer": {
@@ -161,10 +245,51 @@
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
@@ -181,10 +306,31 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "colour": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -208,6 +354,31 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "crypto-js": {
       "version": "3.1.9-1",
@@ -255,6 +426,24 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
@@ -287,10 +476,43 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "express": {
       "version": "4.17.1",
@@ -343,6 +565,16 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -357,6 +589,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "google-protobuf": {
       "version": "3.10.0",
@@ -847,10 +1094,22 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "hosted-git-info": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
@@ -864,12 +1123,47 @@
         "toidentifier": "1.0.0"
       }
     },
+    "husky": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
+      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "read-pkg": "^5.2.0",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "inherits": {
@@ -887,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -896,6 +1196,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -913,6 +1219,12 @@
         "has": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -921,12 +1233,55 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "^1.0.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
@@ -964,6 +1319,12 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -987,15 +1348,49 @@
         "mime-db": "1.40.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      }
     },
     "nan": {
       "version": "2.14.0",
@@ -1006,6 +1401,33 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1039,6 +1461,30 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
+    },
     "optjs": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
@@ -1052,15 +1498,201 @@
         "lcid": "^1.0.0"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
+    "pretty-quick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.0.tgz",
+      "integrity": "sha512-PcM4S8nTMloTWl1KRkvkf0wAd4+WMH1Lzysey/xyTF5736bwltVyZXlnzP8l/0qUrpvmtzIpm2ecYiX84Qf5Yg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "execa": "^2.1.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.4",
+        "multimatch": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "promisify-call": {
       "version": "2.0.4",
@@ -1106,6 +1738,16 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -1127,6 +1769,53 @@
         "unpipe": "1.0.0"
       }
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1141,6 +1830,18 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",
@@ -1185,6 +1886,71 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -1226,6 +1992,27 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1235,6 +2022,12 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -1264,10 +2057,29 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.4",
@@ -1287,6 +2099,12 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.22",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,15 @@
     "lodash": "^4.6.1",
     "minimist": "^1.2.0",
     "xml2js": "^0.4.22"
+  },
+  "devDependencies": {
+    "husky": "^3.0.9",
+    "prettier": "1.18.2",
+    "pretty-quick": "^2.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Document</title>
     <script src="https://visjs.github.io/vis-network/dist/vis-network.min.js"></script>
     <script src="./index.js"></script>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
-    <div id="mynetwork"></div>          
-</body>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="mynetwork"></div>
+  </body>
 </html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,51 +1,53 @@
-async function loadData(){
-    const response = await fetch("./data");
-    const myJson = await response.json();
-    
-    const nodes = Object.values(myJson)
-    .map(({id, ip, port}) =>({
-        id, label: `${id} on ${ip}:${port}`
+async function loadData() {
+  const response = await fetch("./data");
+  const myJson = await response.json();
+
+  const nodes = Object.values(myJson).map(({ id, ip, port }) => ({
+    id,
+    label: `${id} on ${ip}:${port}`
+  }));
+
+  const edges = Object.values(myJson)
+    .filter(
+      elem => !isNaN(elem.id) && elem.successor && !isNaN(elem.successor.id)
+    )
+    .map(({ id, successor }) => ({
+      from: id,
+      to: successor.id
     }));
-    
-    const edges = Object.values(myJson)
-        .filter(elem => !isNaN(elem.id) && elem.successor && !isNaN(elem.successor.id))
-        .map(({id, successor}) =>({
-            from: id, to: successor.id
-        }));
-    // create a network
-    var container = document.getElementById("mynetwork");
-    var data = {
+  // create a network
+  var container = document.getElementById("mynetwork");
+  var data = {
     nodes: nodes,
     edges: edges
-    };
-    var options = {
-        autoResize: true,
-        layout: {
-            randomSeed: 0,
-        },
-        nodes: {
-            shape: "box",
-            font: "24px arial"
-        },
-        physics: {
-            enabled: true,
-            repulsion: {
-                nodeDistance: 300,
-                springLength: 400
-            },
-            solver: "repulsion"
-        }
-    };
-    var network = new vis.Network(container, data, options);
-    setTimeout(() => {
-        network.redraw();
-    }, 100)
-    
+  };
+  var options = {
+    autoResize: true,
+    layout: {
+      randomSeed: 0
+    },
+    nodes: {
+      shape: "box",
+      font: "24px arial"
+    },
+    physics: {
+      enabled: true,
+      repulsion: {
+        nodeDistance: 300,
+        springLength: 400
+      },
+      solver: "repulsion"
+    }
+  };
+  var network = new vis.Network(container, data, options);
+  setTimeout(() => {
+    network.redraw();
+  }, 100);
 }
 
-document.addEventListener("DOMContentLoaded", function(){
+document.addEventListener("DOMContentLoaded", function() {
+  loadData();
+  setInterval(() => {
     loadData();
-    setInterval(()=> {
-        loadData();
-    }, 3000)
+  }, 3000);
 });

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,6 @@
-html, body, #mynetwork {
-    width: 100%;
-    height: 100%;
+html,
+body,
+#mynetwork {
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
Resolve #36 
Prettier is an automatic code formatter that cleans up code on save. Editorconfig is a editor-neutral way to configure line endings and tabs/spaces. This PR adds both to our project.

Because I ran the formatting tool against all of our source files, this commit is "noisy." The AST is unchanged though, so you only really have to look at the config files I changed and confirm behavior. In theory, this should means, we all have consistent auto-formatting, so we won't have as noisy of commits in the future.

Steps:
1. `npm install`
2. Install the Prettier, Proto3, and EditorConfig extensions. I've set these as "workspace recommended extensions," so you should get a popup that suggests that you install these things.
3. Make some changes to a file with sloppy formatting and save. You should see the file auto-magically get formatted. Discard the changes.