### PR TITLE
[WIP] feat: only redraw when data actually changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Document</title>
     <script src="https://visjs.github.io/vis-network/dist/vis-network.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
     <script src="./index.js"></script>
     <link rel="stylesheet" href="style.css" />
   </head>

--- a/public/index.js
+++ b/public/index.js
@@ -1,3 +1,19 @@
+let network;
+let oldData;
+
+// The dataviz library assigns the edges UIDs that we want to ignore when comparing with lodash
+function isEqual(oldData, newData) {
+  const oldDataWithoutEdgeIds = {
+    nodes: oldData.nodes,
+    edges: oldData.edges.map(({ from, to }) => ({ from, to }))
+  };
+  const newDataWithoutEdgeIds = {
+    nodes: newData.nodes,
+    edges: newData.edges.map(({ from, to }) => ({ from, to }))
+  };
+  return _.isEqual(oldDataWithoutEdgeIds, newDataWithoutEdgeIds);
+}
+
 async function loadData() {
   const response = await fetch("./data");
   const myJson = await response.json();
@@ -44,10 +60,16 @@ async function loadData() {
       solver: "repulsion"
     }
   };
-  var network = new vis.Network(container, data, options);
-  setTimeout(() => {
-    network.redraw();
-  }, 100);
+  if (!network) {
+    network = new vis.Network(container, data, options);
+    oldData = data;
+  }
+
+  if (!isEqual(data, oldData)) {
+    console.log("Redraw");
+    network.setData(data);
+    oldData = data;
+  }
 }
 
 document.addEventListener("DOMContentLoaded", function() {

--- a/public/index.js
+++ b/public/index.js
@@ -66,7 +66,6 @@ async function loadData() {
   }
 
   if (!isEqual(data, oldData)) {
-    console.log("Redraw");
     network.setData(data);
     oldData = data;
   }


### PR DESCRIPTION
Resolves #25 

The web app used to redraw every 3 seconds, now it checks the incoming data every three seconds and only redraws when the data has changes. I've left a console log that fires every time it redraws to show this. I'll remove the console log after this is reviewed.