### PR TITLE
fix: simplify callback function for lookupUserRemoteHelper

### DIFF
--- a/node.js
+++ b/node.js
@@ -228,21 +228,9 @@ async function lookup(message, callback) {
         PROTO_PATH,
         "Node"
       );
-      await successorClient.lookupUserRemoteHelper(
-        { id: userId },
-        (err, user) => {
-          if (err) {
-            callback(err, null);
-            console.error(err);
-          } else {
-            console.log("lookup: user from remote: ", user);
-            callback(err, user);
-          }
-        }
-      );
+      const user = await successorClient.lookupUserRemoteHelper({ id: userId });
+      callback(null, user);
     } catch (err) {
-      // I'm not sure if the try/catch is necessary
-      // the idea is in case the client does not work, not the user is not found
       console.error("lookup call to lookupUser failed with ", err);
       callback(err, null);
     }


### PR DESCRIPTION
Resolves #59 

I was a bit confused thinking I needed to receive both the error and the User. I can just assume the error is null and receive a User because in case the user is not found and code 5 is returned,  there is a try/catch that handles that.