### PR TITLE
63 ip to hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ npm install
 Then run start the first node:
 
 ```sh
-npm run devServer -- --ip localhost --port 8440 --id 0 --targetIp localhost --targetPort 8440 --targetId 0
+npm run devServer -- --host localhost --port 8440 --knownHost localhost --knownPort 8440
 ```
 
 Then start the client:
 
 ```sh
-npm run devClient -- crawl --ip localhost --port 8440 --webPort 1337
+npm run devClient -- crawl --host localhost --port 8440 --webPort 1337
 ```
 
 Then open localhost:1337 in a browser
@@ -36,11 +36,11 @@ Then open localhost:1337 in a browser
 Then run the following commands one at a time in separate tabs:
 
 ```sh
-npm run devServer -- --ip localhost --port 8441 --id 6 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8442 --id 1 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8443 --id 2 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8445 --id 3 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8444 --id 7 --targetIp localhost --targetPort 8440 --targetId 0
+npm run devServer -- --host localhost --port 8441 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8444 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8446 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8448 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8450 --knownHost localhost --knownPort 8440
 ```
 
 ## License

--- a/client.js
+++ b/client.js
@@ -3,12 +3,14 @@ const path = require("path");
 const caller = require("grpc-caller");
 const PROTO_PATH = path.resolve(__dirname, "./protos/chord.proto");
 
-const HOST = "127.0.0.1";
+const CRAWLER_INTERVAL_MS = 1000;
+const DEFAULT_HOST_NAME = "localhost";
+const DEFAULT_HOST_PORT = 1337;
 const DUMMY_REQUEST_OBJECT = { id: 99 };
 
 const target = {
-  ip: HOST,
-  port: 1337
+  host: DEFAULT_HOST_NAME,
+  port: DEFAULT_HOST_PORT
 };
 
 let client;
@@ -99,7 +101,7 @@ async function summary() {
   try {
     const node = await client.summary({ id: 1 });
     console.log(
-      `The node returned id: ${node.id}, ip: ${node.ip}, port: ${node.port}`
+      `The node returned id: ${node.id}, host: ${node.host}, port: ${node.port}`
     );
   } catch (err) {
     console.error(err);
@@ -107,8 +109,8 @@ async function summary() {
 }
 
 class ChordCrawler {
-  constructor(ip, port, stepInMS) {
-    this.ip = ip;
+  constructor(host, port, stepInMS) {
+    this.host = host;
     this.port = port;
     this.state = {};
     this.walk = new Set([]);
@@ -138,7 +140,7 @@ class ChordCrawler {
     }
   }
   updateNode(node) {
-    const connectionString = `${node.ip}:${node.port}`;
+    const connectionString = `${node.host}:${node.port}`;
     this.state[connectionString] = {
       ...this.state[connectionString],
       ...node
@@ -148,7 +150,9 @@ class ChordCrawler {
     // If we have trouble reaching a node, just shuffle to any other node and walk from there
     const otherNodes = Object.values(this.state).filter(
       node =>
-        (node.ip !== this.ip || node.port !== this.port) && this.ip && this.port
+        (node.host !== this.host || node.port !== this.port) &&
+        this.host &&
+        this.port
     );
 
     // Just return if we don't have any possible alternatives
@@ -159,14 +163,14 @@ class ChordCrawler {
     const randomNode =
       otherNodes[Math.floor(Math.random() * otherNodes.length)];
 
-    this.ip = randomNode.ip;
+    this.host = randomNode.host;
     this.port = randomNode.port;
 
     // And we have to invalidate the current walk to avoid accidental pruning
     this.walk.clear();
   }
   async crawl() {
-    const connectionString = `${this.ip}:${this.port}`;
+    const connectionString = `${this.host}:${this.port}`;
     console.log(`Connecting to ${connectionString}`);
     const client = caller(connectionString, PROTO_PATH, "Node");
 
@@ -177,7 +181,7 @@ class ChordCrawler {
       this.pruneUponCycle(connectionString);
       this.updateSuccessor(connectionString, successorNode);
       this.updateNode(successorNode);
-      this.ip = successorNode.ip;
+      this.host = successorNode.host;
       this.port = successorNode.port;
     } catch (err) {
       console.error("Error is : ", err);
@@ -190,18 +194,18 @@ function main() {
   if (process.argv.length >= 3) {
     const args = minimist(process.argv.slice(3));
 
-    console.log(args);
+    console.log("The command-line arguments were:\n", args);
 
-    if (args.ip) {
-      target.ip = args.ip;
+    if (args.host) {
+      target.host = args.host;
     }
     if (args.port) {
       target.port = args.port;
     }
 
-    console.log(`Connecting to ${target.ip}:${target.port}`);
+    console.log(`Connecting to ${target.host}:${target.port}`);
 
-    client = caller(`localhost:${target.port}`, PROTO_PATH, "Node");
+    client = caller(`${target.host}:${target.port}`, PROTO_PATH, "Node");
 
     const command = process.argv[2];
 
@@ -224,10 +228,15 @@ function main() {
         summary();
         break;
       case "crawl":
-        let crawler = new ChordCrawler(target.ip, target.port, 3000);
+        let crawler = new ChordCrawler(
+          target.host,
+          target.port,
+          CRAWLER_INTERVAL_MS
+        );
         const express = require("express");
         const app = express();
-        const port = args.webPort || 3000;
+        // TBD is this OR a bug?
+        const port = args.webPort || CRAWLER_INTERVAL_MS;
         app.use(express.static("public"));
         app.get("/data", (req, res) => res.json(crawler.state));
         app.listen(port, () =>

--- a/client.js
+++ b/client.js
@@ -235,8 +235,7 @@ function main() {
         );
         const express = require("express");
         const app = express();
-        // TBD is this OR a bug?
-        const port = args.webPort || CRAWLER_INTERVAL_MS;
+        const port = args.webPort || DEFAULT_HOST_PORT;
         app.use(express.static("public"));
         app.get("/data", (req, res) => res.json(crawler.state));
         app.listen(port, () =>

--- a/commands.md
+++ b/commands.md
@@ -11,10 +11,10 @@ npm run devServer -- --host localhost --port 8450 --knownHost localhost --knownP
 
 <!-- Alvaro: npm run devClient worked for me, but it does not ends so I can't run the following command -->
 
-node client insert --host localhost --port 8440
-node client insert --host localhost --port 8440 --displayName "Alvaro is cool" --reputation 99 --aboutMe "I'm so cool I need no description"
-node client lookup --host localhost --port 8440
-node client remove --host localhost --port 8440
+node client insert --host localhost --port 8440 --id 2
+node client insert --host localhost --port 8440 --id 5 --displayName "Alvaro is cool" --reputation 99 --aboutMe "I'm so cool I need no description"
+node client lookup --host localhost --port 8440 --id 2
+node client remove --host localhost --port 8440 --id 2
 
 # Manual with Docker
 

--- a/commands.md
+++ b/commands.md
@@ -26,3 +26,9 @@ docker build -t bushidocodes/chordweb -f ./ClientDockerfile .
 docker run -p 8440:1337 -it --init bushidocodes/chord --knownHost host.docker.internal --knownPort 8440
 docker run -p 8441:1337 -it --init bushidocodes/chord --knownHost host.docker.internal --knownPort 8440
 docker run -p 1337:1337 -it --init bushidocodes/chordweb crawl --host host.docker.internal --port 8440 --webPort 1337
+
+# Automatic with Docker
+
+docker-compose down
+docker-compose up --build
+google-chrome -incognito --password-store=basic --new-window http://localhost:1337 &

--- a/commands.md
+++ b/commands.md
@@ -1,28 +1,28 @@
 # Manual without Docker
 
-npm run devServer -- --ip localhost --port 8440 --id 0 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devClient -- crawl --ip localhost --port 8440 --webPort 1337
+npm run devServer -- --host localhost --port 8440 --knownHost localhost --knownPort 8440
+npm run devClient -- crawl --host localhost --port 8440 --webPort 1337
 
-npm run devServer -- --ip localhost --port 8441 --id 6 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8442 --id 1 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8443 --id 2 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8445 --id 3 --targetIp localhost --targetPort 8440 --targetId 0
-npm run devServer -- --ip localhost --port 8444 --id 7 --targetIp localhost --targetPort 8440 --targetId 0
+npm run devServer -- --host localhost --port 8441 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8444 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8446 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8448 --knownHost localhost --knownPort 8440
+npm run devServer -- --host localhost --port 8450 --knownHost localhost --knownPort 8440
 
 <!-- Alvaro: npm run devClient worked for me, but it does not ends so I can't run the following command -->
 
-node client insert --ip localhost --port 8440 --id 2
-node client insert --ip localhost --port 8440 --id 5 --displayName "Alvaro is cool" --reputation 99 --aboutMe "I'm so cool I need no description"
-node client lookup --ip localhost --port 8440 --id 2
-node client remove --ip localhost --port 8440 --id 2
+node client insert --host localhost --port 8440
+node client insert --host localhost --port 8440 --displayName "Alvaro is cool" --reputation 99 --aboutMe "I'm so cool I need no description"
+node client lookup --host localhost --port 8440
+node client remove --host localhost --port 8440
 
 # Manual with Docker
 
-I can't get the containers to communicate with each other. No idea about what IP should be used
+I can't get the containers to communicate with each other. No idea about what IP or host name should be used
 
 docker build -t bushidocodes/chord -f ./NodeDockerfile .
 docker build -t bushidocodes/chordweb -f ./ClientDockerfile .
 
-docker run -p 8440:1337 -it --init bushidocodes/chord --id 0 --targetIp host.docker.internal --targetPort 8440 --targetId 0
-docker run -p 8441:1337 -it --init bushidocodes/chord --id 6 --targetIp host.docker.internal --targetPort 8440 --targetId 0
-docker run -p 1337:1337 -it --init bushidocodes/chordweb crawl --ip host.docker.internal --port 8440 --webPort 1337
+docker run -p 8440:1337 -it --init bushidocodes/chord --knownHost host.docker.internal --knownPort 8440
+docker run -p 8441:1337 -it --init bushidocodes/chord --knownHost host.docker.internal --knownPort 8440
+docker run -p 1337:1337 -it --init bushidocodes/chordweb crawl --host host.docker.internal --port 8440 --webPort 1337

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --host node9 --knownHost node0 --knownPort 1337
-  node1:
+    command: npm run devServer -- --host node0 --knownHost node0 --knownPort 1337
+  node2:
     build:
       context: .
       dockerfile: NodeDockerfile
@@ -16,22 +16,13 @@ services:
     command: npm run devServer -- --host node2 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
-  node2:
-    build:
-      context: .
-      dockerfile: NodeDockerfile
-    # image: chordnode
-    # container_name: chordnode
-    command: npm run devServer -- --host node0 --knownHost node0 --knownPort 1337
-    depends_on:
-      - node0
   node3:
     build:
       context: .
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --host node6 --knownHost node0 --knownPort 1337
+    command: npm run devServer -- --host node3 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   node4:
@@ -43,22 +34,40 @@ services:
     command: npm run devServer -- --host node4 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
-  node5:
-    build:
-      context: .
-      dockerfile: NodeDockerfile
-    # image: chordnode
-    # container_name: chordnode
-    command: npm run devServer -- --host node3 --knownHost node0 --knownPort 1337
-    depends_on:
-      - node0
   node6:
     build:
       context: .
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --host node7 --knownHost node0 --knownPort 1337
+    command: npm run devServer -- --host node6 --knownHost node0 --knownPort 1337
+    depends_on:
+      - node0
+  node9:
+    build:
+      context: .
+      dockerfile: NodeDockerfile
+    # image: chordnode
+    # container_name: chordnode
+    command: npm run devServer -- --host node9 --knownHost node0 --knownPort 1337
+    depends_on:
+      - node0
+  node11:
+    build:
+      context: .
+      dockerfile: NodeDockerfile
+    # image: chordnode
+    # container_name: chordnode
+    command: npm run devServer -- --host node11 --knownHost node0 --knownPort 1337
+    depends_on:
+      - node0
+  node15:
+    build:
+      context: .
+      dockerfile: NodeDockerfile
+    # image: chordnode
+    # container_name: chordnode
+    command: npm run devServer -- --host node15 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   client:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node0 --id 0 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node9 --knownHost node0 --knownPort 1337
   node1:
     build:
       context: .
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node1 --id 6 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node2 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   node2:
@@ -22,7 +22,7 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node2 --id 1 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node0 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   node3:
@@ -31,7 +31,7 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node3 --id 2 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node6 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   node4:
@@ -40,7 +40,7 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node4 --id 3 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node4 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   node5:
@@ -49,7 +49,16 @@ services:
       dockerfile: NodeDockerfile
     # image: chordnode
     # container_name: chordnode
-    command: npm run devServer -- --ip node5 --id 7 --targetIp node0 --targetPort 1337 --targetId 0
+    command: npm run devServer -- --host node3 --knownHost node0 --knownPort 1337
+    depends_on:
+      - node0
+  node6:
+    build:
+      context: .
+      dockerfile: NodeDockerfile
+    # image: chordnode
+    # container_name: chordnode
+    command: npm run devServer -- --host node7 --knownHost node0 --knownPort 1337
     depends_on:
       - node0
   client:
@@ -65,4 +74,4 @@ services:
     # volumes:
     #   - .:/home/node/app
     #   - /home/node/app/node_modules/
-    command: npm run devClient -- crawl --ip node0 --port 1337 --webPort 1337
+    command: npm run devClient -- crawl --host node0 --port 1337 --webPort 1337

--- a/node.js
+++ b/node.js
@@ -26,7 +26,7 @@ const HASH_BIT_LENGTH = 3;
 const CHECK_NODE_TIMEOUT_ms = 1000;
 const DEFAULT_HOST_NAME = "localhost";
 const DEFAULT_HOST_PORT = 1337;
-const NULL_NODE = { id: null, ip: null, port: null };
+const NULL_NODE = { id: null, host: null, port: null };
 const NULL_USER = { id: null };
 let fingerTable = [
   {
@@ -95,7 +95,7 @@ async function remove(message, callback) {
       console.log("In remove: remove user from remote node");
       console.log(userId);
       const successorClient = caller(
-        `${successor.ip}:${successor.port}`,
+        `${successor.host}:${successor.port}`,
         PROTO_PATH,
         "Node"
       );
@@ -160,7 +160,7 @@ async function insert(message, callback) {
       console.log("In insert: insert user to remote node");
       console.log(user, lookupKey);
       const successorClient = caller(
-        `${successor.ip}:${successor.port}`,
+        `${successor.host}:${successor.port}`,
         PROTO_PATH,
         "Node"
       );
@@ -226,7 +226,7 @@ async function lookup(message, callback) {
     try {
       console.log("In lookup: lookup user to remote node");
       const successorClient = caller(
-        `${successor.ip}:${successor.port}`,
+        `${successor.host}:${successor.port}`,
         PROTO_PATH,
         "Node"
       );
@@ -322,7 +322,7 @@ async function findSuccessor(id, nodeQuerying, nodeQueried) {
   } else {
     // create client for remote call
     const nodeQueriedClient = caller(
-      `${nodeQueried.ip}:${nodeQueried.port}`,
+      `${nodeQueried.host}:${nodeQueried.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -505,7 +505,7 @@ async function getSuccessor(nodeQuerying, nodeQueried) {
     // use remote value
     // create client for remote call
     const nodeQueriedClient = caller(
-      `${nodeQueried.ip}:${nodeQueried.port}`,
+      `${nodeQueried.host}:${nodeQueried.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -516,7 +516,7 @@ async function getSuccessor(nodeQuerying, nodeQueried) {
       );
     } catch (err) {
       // TBD 20191103.hk: why does "nSuccessor = NULL_NODE;" not do the same as explicit?!?!
-      nSuccessor = { id: null, ip: null, port: null };
+      nSuccessor = { id: null, host: null, port: null };
       console.trace("Remote error in getSuccessor() ", err);
     }
   }
@@ -579,7 +579,7 @@ async function closestPrecedingFinger(id, nodeQuerying, nodeQueried) {
     // use remote value
     // create client for remote call
     const nodeQueriedClient = caller(
-      `${nodeQueried.ip}:${nodeQueried.port}`,
+      `${nodeQueried.host}:${nodeQueried.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -668,7 +668,7 @@ async function setPredecessor(message, callback) {
  * Modification consists of an additional step of initializing the successor table
  *   as described in the IEEE paper.
  *
- * @param knownNode: knownNode structure; e.g., {id, ip, port}
+ * @param knownNode: knownNode structure; e.g., {id, host, port}
  *   Pass a null known node to force the node to be the first in a new chord.
  */
 async function join(knownNode) {
@@ -725,7 +725,7 @@ async function join(knownNode) {
 
 /**
  * Determine whether a node exists by pinging it.
- * @param knownNode: knownNode structure; e.g., {id, ip, port}
+ * @param knownNode: knownNode structure; e.g., {id, host, port}
  * @returns {boolean}
  */
 function confirmExist(knownNode) {
@@ -769,7 +769,7 @@ async function initFingerTable(nPrime) {
 
   // client for newly-determined successor
   let successorClient = caller(
-    `${fingerTable[0].successor.ip}:${fingerTable[0].successor.port}`,
+    `${fingerTable[0].successor.host}:${fingerTable[0].successor.port}`,
     PROTO_PATH,
     "Node"
   );
@@ -884,7 +884,7 @@ async function updateOthers() {
 
     // p.updateFingerTable(n, i);
     if (_self.id !== pNode.id) {
-      pNodeClient = caller(`${pNode.ip}:${pNode.port}`, PROTO_PATH, "Node");
+      pNodeClient = caller(`${pNode.host}:${pNode.port}`, PROTO_PATH, "Node");
       try {
         await pNodeClient.updateFingerTable({ node: _self, index: i });
       } catch (err) {
@@ -936,7 +936,7 @@ async function updateFingerTable(message, callback) {
     fingerTable[fingerIndex].successor = sNode;
     // p = predecessor;
     const pClient = caller(
-      `${predecessor.ip}:${predecessor.port}`,
+      `${predecessor.host}:${predecessor.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -1042,7 +1042,7 @@ async function updateSuccessorTable() {
   }
   if (successorTable.length < 1) {
     // this node is isolated
-    successorTable.push({ id: _self.id, ip: _self.ip, port: _self.port });
+    successorTable.push({ id: _self.id, host: _self.host, port: _self.port });
   }
   // try to bulk up the table
   let successorSuccessor = NULL_NODE;
@@ -1067,7 +1067,7 @@ async function updateSuccessorTable() {
           `updateSuccessorTable call to getSuccessor failed with `,
           err
         );
-        successorSuccessor = { id: null, ip: null, port: null };
+        successorSuccessor = { id: null, host: null, port: null };
       }
       if (DEBUGGING_LOCAL) {
         console.log(
@@ -1102,7 +1102,7 @@ async function updateSuccessorTable() {
   // prune from the bottom
   let i = successorTable.length - 1;
   successorSeemsOK = false;
-  successorSuccessor = { id: null, ip: null, port: null };
+  successorSuccessor = { id: null, host: null, port: null };
   while (
     (!successorSeemsOK || successorTable.length > HASH_BIT_LENGTH) &&
     i > 0
@@ -1152,7 +1152,7 @@ async function stabilize() {
   let x;
   try {
     successorClient = caller(
-      `${fingerTable[0].successor.ip}:${fingerTable[0].successor.port}`,
+      `${fingerTable[0].successor.host}:${fingerTable[0].successor.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -1205,7 +1205,7 @@ async function stabilize() {
   // successor.notify(n);
   if (_self.id !== fingerTable[0].successor.id) {
     successorClient = caller(
-      `${fingerTable[0].successor.ip}:${fingerTable[0].successor.port}`,
+      `${fingerTable[0].successor.host}:${fingerTable[0].successor.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -1342,7 +1342,7 @@ async function fixFingers() {
 async function checkPredecessor() {
   if (predecessor.id !== null && predecessor.id !== _self.id) {
     const predecessorClient = caller(
-      `${predecessor.ip}:${predecessor.port}`,
+      `${predecessor.host}:${predecessor.port}`,
       PROTO_PATH,
       "Node"
     );
@@ -1354,7 +1354,7 @@ async function checkPredecessor() {
         `checkPredecessor call to getPredecessor failed with `,
         err
       );
-      predecessor = { id: null, ip: null, port: null };
+      predecessor = { id: null, host: null, port: null };
       return false;
     }
   }
@@ -1427,11 +1427,11 @@ async function migrateKeys() {}
  * sample server port
  *
  * Takes the following mandatory flags
- * --ip         - This node's IP Address
+ * --host       - This node's host name
  * --port       - This node's TCP Port
  *
  * --targetId   - The ID of a node in the cluster
- * --targetIp   - The IP of a node in the cluster
+ * --targetHost   - The host name of a node in the cluster
  * --targetPort - The TCP Port of a node in the cluster
  *
  * And takes the following optional flags
@@ -1446,7 +1446,7 @@ async function main() {
 
   // compute identity parameters from arguments
   _self.id = args.id ? args.id : null;
-  _self.ip = args.ip ? args.ip : DEFAULT_HOST_NAME;
+  _self.host = args.host ? args.host : DEFAULT_HOST_NAME;
   _self.port = args.port ? args.port : DEFAULT_HOST_PORT;
   // protect against bad ID inputs
   if (_self.id && _self.id > 2 ** HASH_BIT_LENGTH - 1) {
@@ -1463,7 +1463,7 @@ async function main() {
   if (!_self.id) {
     try {
       _self.id = await computeIntegerHash(
-        _self.ip + _self.port,
+        _self.host + _self.port,
         HASH_BIT_LENGTH
       );
       console.log(
@@ -1477,7 +1477,7 @@ async function main() {
       console.error(
         "Error computing node ID from hash.",
         "Input was ",
-        _self.ip + _self.port,
+        _self.host + _self.port,
         "but hash output was ",
         _self.id,
         ".",
@@ -1490,7 +1490,7 @@ async function main() {
 
   // sanitize known ID parameters
   let knownNodeId = args.targetId ? args.targetId : null;
-  let knownNodeIp = args.targetIp ? args.targetIp : DEFAULT_HOST_NAME;
+  let knownNodeHost = args.targetHost ? args.targetHost : DEFAULT_HOST_NAME;
   let knownNodePort = args.targetPort ? args.targetPort : DEFAULT_HOST_PORT;
   // protect against bad Known ID inputs
   if (knownNodeId && knownNodeId > 2 ** HASH_BIT_LENGTH - 1) {
@@ -1507,7 +1507,7 @@ async function main() {
   if (!knownNodeId) {
     try {
       knownNodeId = await computeIntegerHash(
-        knownNodeIp + knownNodePort,
+        knownNodeHost + knownNodePort,
         HASH_BIT_LENGTH
       );
       console.log(
@@ -1519,9 +1519,9 @@ async function main() {
       );
     } catch (err) {
       console.error(
-        "Error computing node ID from hash.",
+        "Error computing the ID of the known node from hash.",
         "Input was ",
-        knownNodeIp + knownNodePort,
+        knownNodeHost + knownNodePort,
         "but hash output was ",
         knownNodeId,
         ".",
@@ -1533,7 +1533,7 @@ async function main() {
   }
 
   // attempt to join new node
-  await join({ id: knownNodeId, ip: knownNodeIp, port: knownNodePort });
+  await join({ id: knownNodeId, host: knownNodeHost, port: knownNodePort });
 
   // periodically run stabilization functions
   setInterval(async () => {
@@ -1569,7 +1569,7 @@ async function main() {
   server.bind(`0.0.0.0:${_self.port}`, grpc.ServerCredentials.createInsecure());
   server.start();
   if (DEBUGGING_LOCAL) {
-    console.log(`Serving on ${_self.ip}:${_self.port}`);
+    console.log(`Serving on ${_self.host}:${_self.port}`);
   }
 }
 

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -35,7 +35,7 @@ message NodeId {
 
 message NodeAddress {
   uint32 id = 1;
-  string ip = 2;
+  string host = 2;
   uint32 port = 3;
 }
 

--- a/public/index.js
+++ b/public/index.js
@@ -1,3 +1,5 @@
+const CRAWLER_INTERVAL_MS = 1000;
+
 let network;
 const nodeSet = new vis.DataSet();
 const edgeSet = new vis.DataSet();
@@ -17,26 +19,28 @@ async function loadData() {
   const response = await fetch("./data");
   const myJson = await response.json();
 
-  const nodes = Object.values(myJson).map(({ id, ip, port }) => ({
-    id: `${ip}:${port}`,
-    label: `${id} on ${ip}:${port}`,
-    data: { id, ip, port }
+  const nodes = Object.values(myJson).map(({ id, host, port }) => ({
+    id: `${host}:${port}`,
+    label: `${id} on ${host}:${port}`,
+    data: { id, host, port }
   }));
 
   const edges = Object.values(myJson)
     .filter(
       elem =>
-        elem.ip &&
+        elem.host &&
         elem.port &&
         elem.successor &&
-        elem.successor.ip &&
+        elem.successor.host &&
         elem.successor.port
     )
-    .map(({ ip, port, successor }) => {
-      let hash = hashCode(`${ip}:${port}-${successor.ip}:${successor.port}`);
+    .map(({ host, port, successor }) => {
+      let hash = hashCode(
+        `${host}:${port}-${successor.host}:${successor.port}`
+      );
       return {
-        from: `${ip}:${port}`,
-        to: `${successor.ip}:${successor.port}`,
+        from: `${host}:${port}`,
+        to: `${successor.host}:${successor.port}`,
         id: hash
       };
     });
@@ -98,5 +102,5 @@ document.addEventListener("DOMContentLoaded", function() {
   loadData();
   setInterval(() => {
     loadData();
-  }, 3000);
+  }, CRAWLER_INTERVAL_MS);
 });


### PR DESCRIPTION
Refactored the code to use "host" instead of "ip" in the definition of a node.

For example, where the proto used to be "NodeAddress {uint32 id = 1; string ip = 2; uint32 port = 3;}", it is now  "NodeAddress {uint32 id = 1; string host = 2; uint32 port = 3;}".

Similarly, the arguments are now "--host" and --"knownHost" instead of "--ip" and "--targetIp", respectively.  Note that I also replaced "target*" with "known*", so "--knownHost", "--knownPort" and - if used optionally - "--knownId".

This obviously caused all the callers to have to be refactored so it cased changes in client.js and index.js.  All of these were fixed and tested, with the two drivers attached.

[driver_hash_manual.sh.txt](https://github.com/bushidocodes/chord-grpc/files/3855259/driver_hash_manual.sh.txt)

[driver_hash_npm_manual.sh.txt](https://github.com/bushidocodes/chord-grpc/files/3855261/driver_hash_npm_manual.sh.txt)

(Please note that GitHub rejects the ".sh" extension so just appended ".txt".  Then you'd have to "chmod u+x driver_*.sh" after renaming.)

In both drivers, just change the "WORKING_DIR" constant near the very top.  The "driver_hash_manual" calls "node node ..." directly, whereas the "driver_hash_npm_manual" calls "npm run devServer -- ..." (or "devClient").

I couldn't unfortunately get the "docker-compose up" call to work although I tried to modify the .yaml file.

In an attempt to fix the docker problem, I added a new feature to the main() of node.js to easily compute the hash of a value from the command line.  So, if you call "node node --hashOnly node0", it will return that the ID would be "2" - output is "ID { 2 } computed from hash of { node0 }".

Using that, I created a list of node names that wouldn't cause collisions. The list is pasted as a comment in the npm driver file:

"# 0 --> node9; 1 --> node2; 2 --> node0; 3 --> node6; 4 --> node4; 5 --> node3; 6 --> node7; 7 --> node1"

In other words, those results are that if "node9" is indeed the only thing hashed, it will create a node with ID 0 - in other words, that's the hash of "node9", not the hash of "node9:84xx".

Similarly, there is a list of deconflicted port numbers for convenience:

"# 0 --> 8441; 1 --> 8448; 2 --> 8454; 3 --> 8444; 4 --> 8446; 5 --> 8450; 6 --> 8451; 7 --> 8440"

Note, however, that these are intended to be hashed in conjuction with the host.  So, "localhost:8441" is what yields a node with ID 0.

This pull request should close issue #63 .

