### PR TITLE
76 implement migrate keys

### DIFF
--- a/app/ChordNode.js
+++ b/app/ChordNode.js
@@ -1034,7 +1034,9 @@ class ChordNode {
   /**
    * Placeholder for data migration within the joinCluster() call.
    */
-  async migrateKeysAfterJoin() {}
+  async migrateKeysAfterJoin() {
+    throw new Error("Method migrateKeysAfterJoin has not been implemented");
+  }
 }
 
 module.exports = {

--- a/app/ChordNode.js
+++ b/app/ChordNode.js
@@ -433,10 +433,10 @@ class ChordNode {
     }
 
     try {
-      console.log("join: calling migrateKys");
+      if (DEBUGGING_LOCAL) console.log("join: calling migrateKys");
       await this.migrateKeysAfterJoin();
     } catch (error) {
-      console.log("Migrate keys failed with error:", error);
+      console.err("Migrate keys failed with error:", error);
     }
 
     // initialize successor table

--- a/app/ChordNode.js
+++ b/app/ChordNode.js
@@ -46,6 +46,10 @@ class ChordNode {
     return this.id == successor.id;
   }
 
+  iAmMyOwnSuccessor() {
+    return this.id == this.fingerTable[0].successor.id;
+  }
+
   iAmMyOwnPredecessor() {
     return this.id == this.predecessor.id;
   }
@@ -428,7 +432,12 @@ class ChordNode {
       this.predecessor = this.encapsulateSelf();
     }
 
-    await this.migrateKeys();
+    try {
+      console.log("join: calling migrateKys");
+      await this.migrateKeysAfterJoin();
+    } catch (error) {
+      console.log("Migrate keys failed with error:", error);
+    }
 
     // initialize successor table
     this.successorTable[0] = this.fingerTable[0].successor;
@@ -1025,7 +1034,7 @@ class ChordNode {
   /**
    * Placeholder for data migration within the joinCluster() call.
    */
-  async migrateKeys() {}
+  async migrateKeysAfterJoin() {}
 }
 
 module.exports = {

--- a/app/ChordNode.js
+++ b/app/ChordNode.js
@@ -436,7 +436,7 @@ class ChordNode {
       if (DEBUGGING_LOCAL) console.log("join: calling migrateKys");
       await this.migrateKeysAfterJoin();
     } catch (error) {
-      console.err("Migrate keys failed with error:", error);
+      console.error("Migrate keys failed with error:", error);
     }
 
     // initialize successor table

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -18,7 +18,8 @@ service Node {
   rpc lookupUserRemoteHelper (UserRequest) returns (User) {}
   rpc remove(UserRequest) returns (google.protobuf.Empty){}
   rpc removeUserRemoteHelper(UserRequest) returns (google.protobuf.Empty){}
-
+  rpc migrateUsersToNewPredecessor(google.protobuf.Empty) returns (google.protobuf.Empty){}
+  
   // Chord Library Level RPC Calls
   rpc findSuccessorRemoteHelper (RemoteId) returns (NodeAddress) {}
   rpc getSuccessorRemoteHelper (NodeAddress) returns (NodeAddress) {}


### PR DESCRIPTION
Resolves #76 

This branch allows to migrate keys to the new predecessor of a node after this joins. 

A way to test it is start a node and insert different users above and below its ID. This node will save all those users.

Then join a new node. Keys that belong to this new node need to be migrated.

Then a breakpoint can be placed and check which nodes has which keys to see it's working. 
Also debug local would allow to see that users were deleted from one node and inserted in the other.

I have added a new issue to handle migratoin after node leaves.