### PR TITLE
feat: prevent collisions

### DIFF
--- a/app/UserService.js
+++ b/app/UserService.js
@@ -50,6 +50,7 @@ class UserService extends ChordNode {
       migrateUsersToNewPredecessor: this.migrateUsersToNewPredecessor.bind(
         this
       ),
+      getNodeIdRemoteHelper: this.getNodeIdRemoteHelper.bind(this),
       findSuccessorRemoteHelper: this.findSuccessorRemoteHelper.bind(this),
       getSuccessorRemoteHelper: this.getSuccessorRemoteHelper.bind(this),
       getPredecessor: this.getPredecessor.bind(this),

--- a/app/node.js
+++ b/app/node.js
@@ -60,6 +60,33 @@ async function main() {
     process.exit(rc);
   }
 
+  // sanitize parameters corresponding to known node
+  // + if no known host or port were provided, it is assumed that they are self's
+  // + such as when starting a new chord; ie, joining itself
+  let knownNodeId = args.knownId ? args.knownId : null;
+  let knownNodeHost = args.knownHost ? args.knownHost : args.host;
+  let knownNodePort = args.knownPort ? args.knownPort : args.port;
+  // protect against bad Known ID inputs
+  if (knownNodeId && knownNodeId > 2 ** HASH_BIT_LENGTH - 1) {
+    console.error(
+      `Error. Bad known ID {${args.knownId}} > [ 2^m-1 --> {${2 **
+        HASH_BIT_LENGTH -
+        1}} ]. Thus, terminating...\n`
+    );
+    return -13;
+  }
+
+  // protect against bad ID inputs
+  if (args.id && args.id > 2 ** HASH_BIT_LENGTH - 1) {
+    console.error(
+      `Error. Bad ID {${args.id}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
+        1}}. Terminating...\n`
+    );
+    return -13;
+  }
+
+  /*
+  TBD 20191127.hk I believe this is no longer necessary with the new collsion checks in join().
   // bail immediately if knownHost can't be reached
   if (
     args.host &&
@@ -72,34 +99,23 @@ async function main() {
       console.error(
         `${args.knownHost}:${args.knownPort} is not responsive. Exiting`
       );
+      console.error("here");
       process.exit(-9);
     } else {
       console.log(`${args.knownHost}:${args.knownPort} responded`);
     }
   }
-
-  // protect against bad ID inputs
-  if (args.id && args.id > 2 ** HASH_BIT_LENGTH - 1) {
-    console.error(
-      `Error. Bad ID {${args.id}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
-        1}}. Terminating...\n`
-    );
-    return -13;
-  }
-
-  // protect against bad Known ID inputs
-  if (args.knownId && args.knownId > 2 ** HASH_BIT_LENGTH - 1) {
-    console.error(
-      `Error. Bad known ID {${args.knownId}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
-        1}}. Thus, terminating...\n`
-    );
-    return -13;
-  }
+  */
 
   try {
     userServiceNode = new UserService({ ...args });
     await userServiceNode.serve();
-    await userServiceNode.joinCluster();
+    let knownNode = {
+      id: knownNodeId,
+      host: knownNodeHost,
+      port: knownNodePort
+    };
+    await userServiceNode.joinCluster(knownNode);
   } catch (err) {
     console.error(err);
     process.exit();

--- a/app/utils.js
+++ b/app/utils.js
@@ -125,7 +125,7 @@ async function computeIntegerHash(stringForHashing) {
 }
 
 async function computeHostPortHash(host, port) {
-  return computeIntegerHash(`${host}:${port}`);
+  return computeIntegerHash(`${host}:${port}`.toLowerCase());
 }
 
 function handleGRPCErrors(scope, call, host, port, err) {

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -21,6 +21,7 @@ service Node {
   rpc migrateUsersToNewPredecessor(google.protobuf.Empty) returns (google.protobuf.Empty){}
   
   // Chord Library Level RPC Calls
+  rpc getNodeIdRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc findSuccessorRemoteHelper (RemoteId) returns (NodeAddress) {}
   rpc getSuccessorRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc getPredecessor (NodeAddress) returns (NodeAddress) {}


### PR DESCRIPTION
the original intention was to implement a graceful 'leave' function.  however, in becoming familiar with the code, it was safer to implement the collision-avoidance feature to close issue #66 .  in order to do that, i front-ported the confirmExist that i had worked on the pre-class branch to also close issue #29 .  in other words, the name of the branch is not good but i believe the branch itself is.

a big departure is that i clobbered the handling of the "known" as a property of the class.  well, technically i left it there since i don't know what other ramifications it has but i made good progress towards its demise.

i'll then have to come back to a new branch to deal with what i really wanted to deal with :-)

happy thanksgiving!!