### PR TITLE
14 leave

### DIFF
--- a/app/ChordNode.js
+++ b/app/ChordNode.js
@@ -11,7 +11,7 @@ const {
 } = require("./utils.js");
 
 class ChordNode {
-  constructor({ id, host, port, knownId, knownHost, knownPort }) {
+  constructor({ id, host, port }) {
     if (!host || !port) {
       console.error(
         "ChordNode constructor did not receive host or port as expected"
@@ -21,17 +21,6 @@ class ChordNode {
     this.id = id;
     this.host = host;
     this.port = port;
-    if (!knownHost || !knownPort) {
-      console.log(
-        "ChordNode constructor did not receive knownHost or knownPort as expected, so setting to host and port"
-      );
-      this.knownHost = host;
-      this.knownPort = port;
-    } else {
-      this.knownHost = knownHost;
-      this.knownPort = knownPort;
-    }
-    this.knownId = knownId;
 
     this.fingerTable = [
       {
@@ -40,7 +29,7 @@ class ChordNode {
       }
     ];
     this.successorTable = [NULL_NODE];
-    //this.predecessor = { id: null, host: null, port: null };
+    //TBD 20191127this.predecessor = { id: null, host: null, port: null };
     this.predecessor = NULL_NODE;
   }
 
@@ -400,12 +389,12 @@ class ChordNode {
     let knownNodeId = null;
     let possibleCollidingNode = NULL_NODE;
 
-    // Generate the ID from the host connection strings if not already forced by user
+    // Generate the for this node ID from the host connection strings if not already forced by user
     if (!this.id) {
       this.id = await computeHostPortHash(this.host, this.port);
     }
 
-    // initialize table with reasonable values
+    // initialize finger table with reasonable values
     this.fingerTable.pop();
     for (let i = 0; i < HASH_BIT_LENGTH; i++) {
       this.fingerTable.push({

--- a/app/UserService.js
+++ b/app/UserService.js
@@ -23,15 +23,8 @@ const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
 const chord = grpc.loadPackageDefinition(packageDefinition).chord;
 
 class UserService extends ChordNode {
-  constructor({
-    id,
-    host = os.hostname(),
-    port = 1337,
-    knownId,
-    knownHost = host,
-    knownPort = port
-  }) {
-    super({ id, host, port, knownId, knownHost, knownPort });
+  constructor({ id, host = os.hostname(), port = 1337 }) {
+    super({ id, host, port });
     this.userMap = {};
   }
 

--- a/app/UserService.js
+++ b/app/UserService.js
@@ -50,6 +50,7 @@ class UserService extends ChordNode {
       migrateUsersToNewPredecessor: this.migrateUsersToNewPredecessor.bind(
         this
       ),
+      getNodeIdRemoteHelper: this.getNodeIdRemoteHelper.bind(this),
       findSuccessorRemoteHelper: this.findSuccessorRemoteHelper.bind(this),
       getSuccessorRemoteHelper: this.getSuccessorRemoteHelper.bind(this),
       getPredecessor: this.getPredecessor.bind(this),

--- a/app/node.js
+++ b/app/node.js
@@ -60,6 +60,33 @@ async function main() {
     process.exit(rc);
   }
 
+  // sanitize parameters corresponding to known node
+  // + if no known host or port were provided, it is assumed that they are self's
+  // + such as when starting a new chord; ie, joining itself
+  let knownNodeId = args.knownId ? args.knownId : null;
+  let knownNodeHost = args.knownHost ? args.knownHost : args.host;
+  let knownNodePort = args.knownPort ? args.knownPort : args.port;
+  // protect against bad Known ID inputs
+  if (knownNodeId && knownNodeId > 2 ** HASH_BIT_LENGTH - 1) {
+    console.error(
+      `Error. Bad known ID {${args.knownId}} > [ 2^m-1 --> {${2 **
+        HASH_BIT_LENGTH -
+        1}} ]. Thus, terminating...\n`
+    );
+    return -13;
+  }
+
+  // protect against bad ID inputs
+  if (args.id && args.id > 2 ** HASH_BIT_LENGTH - 1) {
+    console.error(
+      `Error. Bad ID {${args.id}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
+        1}}. Terminating...\n`
+    );
+    return -13;
+  }
+
+  /*
+  TBD 20191127.hk I believe this is no longer necessary with the new collsion checks in join().
   // bail immediately if knownHost can't be reached
   if (
     args.host &&
@@ -72,34 +99,23 @@ async function main() {
       console.error(
         `${args.knownHost}:${args.knownPort} is not responsive. Exiting`
       );
+      console.error("here");
       process.exit(-9);
     } else {
       console.log(`${args.knownHost}:${args.knownPort} responded`);
     }
   }
-
-  // protect against bad ID inputs
-  if (args.id && args.id > 2 ** HASH_BIT_LENGTH - 1) {
-    console.error(
-      `Error. Bad ID {${args.id}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
-        1}}. Terminating...\n`
-    );
-    return -13;
-  }
-
-  // protect against bad Known ID inputs
-  if (args.knownId && args.knownId > 2 ** HASH_BIT_LENGTH - 1) {
-    console.error(
-      `Error. Bad known ID {${args.knownId}} > 2^m-1 {${2 ** HASH_BIT_LENGTH -
-        1}}. Thus, terminating...\n`
-    );
-    return -13;
-  }
+  */
 
   try {
     userServiceNode = new UserService({ ...args });
     await userServiceNode.serve();
-    await userServiceNode.joinCluster();
+    let knownNode = {
+      id: knownNodeId,
+      host: knownNodeHost,
+      port: knownNodePort
+    };
+    await userServiceNode.joinCluster(knownNode);
   } catch (err) {
     console.error(err);
     process.exit();

--- a/app/utils.js
+++ b/app/utils.js
@@ -125,7 +125,7 @@ async function computeIntegerHash(stringForHashing) {
 }
 
 async function computeHostPortHash(host, port) {
-  return computeIntegerHash(`${host}:${port}`);
+  return computeIntegerHash(`${host}:${port}`.toLowerCase());
 }
 
 function handleGRPCErrors(scope, call, host, port, err) {

--- a/app/utils.js
+++ b/app/utils.js
@@ -5,7 +5,7 @@ const caller = require("grpc-caller");
 const PROTO_PATH = path.resolve(__dirname, "../protos/chord.proto");
 
 const HASH_BIT_LENGTH = 8;
-const SUCCESSOR_TABLE_MAX_LENGTH = Math.ceil(HASH_BIT_LENGTH / 4);
+const SUCCESSOR_TABLE_MAX_LENGTH = Math.max(Math.ceil(HASH_BIT_LENGTH / 4), 1);
 const NULL_NODE = { id: null, host: null, port: null };
 const DEBUGGING_LOCAL = false;
 

--- a/app/utils.js
+++ b/app/utils.js
@@ -5,6 +5,7 @@ const caller = require("grpc-caller");
 const PROTO_PATH = path.resolve(__dirname, "../protos/chord.proto");
 
 const HASH_BIT_LENGTH = 8;
+const SUCCESSOR_TABLE_MAX_LENGTH = Math.ceil(HASH_BIT_LENGTH / 4);
 const NULL_NODE = { id: null, host: null, port: null };
 const DEBUGGING_LOCAL = false;
 
@@ -235,5 +236,6 @@ module.exports = {
   sha1,
   DEBUGGING_LOCAL,
   HASH_BIT_LENGTH,
+  SUCCESSOR_TABLE_MAX_LENGTH,
   NULL_NODE
 };

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -21,6 +21,7 @@ service Node {
   rpc migrateUsersToNewPredecessor(google.protobuf.Empty) returns (google.protobuf.Empty){}
   
   // Chord Library Level RPC Calls
+  rpc getNodeIdRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc findSuccessorRemoteHelper (RemoteId) returns (NodeAddress) {}
   rpc getSuccessorRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc getPredecessor (NodeAddress) returns (NodeAddress) {}


### PR DESCRIPTION
Resolves #66 
Resolves #29 
Resolves #31 

the original intention was to implement a graceful 'leave' function. however, in becoming familiar with the code, it was safer to implement the collision-avoidance feature to close issue #66 . in order to do that, i front-ported the confirmExist that i had worked on the pre-class branch to also close issue #29 . in other words, the name of the branch is not good but i believe the branch itself is.

in particular, i believe it does close issue #31 , which is related to leaving in that now the "ungraceful" leaving of nodes (e.g., when you just "ctrl+c" some nodes) works much more robustly.  You can still cause hurt but it does work MUCH better, to include the problem with "last-node-standing" is now stable.  In fact, you can actually add nodes to last-node-standing and then kill one of the two, then add some more.

The code was tested in "node node", "npm run" and docker-compose modes.  The first two work a bit better in that docker-compose scale-down is SO fast that it's just hard to keep up.  You can notice this in that the picture will often show the 'primary' missing, which is obviously not true.  But, much better than before and sets us up for the .... elusive 'graceful' leave :-)

beyond adding functionality, a big departure is that i clobbered the handling of the "known" as a property of the class.

i'll then have to come back to a new branch to deal with what i really wanted to deal with :-)

happy thanksgiving!!