### PR TITLE
14 graceful leave

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -25,9 +25,6 @@ export class ChordNode {
   id: number;
   host: string;
   port: number;
-  knownId: number;
-  knownHost: string;
-  knownPort: number;
   fingerTable: Array<FingerTableEntry>;
   successorTable: Array<Node>;
   predecessor: Node;
@@ -435,6 +432,7 @@ export class ChordNode {
     ) {
       // this is the first node in a new cluster
       this.predecessor = this.encapsulateSelf();
+      knownNode.id = this.id;
     } else if (await this.confirmExist(knownNode)) {
       // joining an existing chord so
       // + get the known node's ID
@@ -497,7 +495,7 @@ export class ChordNode {
     if (DEBUGGING_LOCAL) {
       console.log(">>>>>     joinCluster          ");
       console.log(
-        `The fingerTable[] leaving {${this.id}}.joinCluster(${this.knownId}) is:\n`,
+        `The fingerTable[] leaving {${this.id}}.joinCluster(${knownNode.id}) is:\n`,
         this.fingerTable
       );
       console.log(

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -67,13 +67,15 @@ export class UserService extends ChordNode {
       getNodeIdRemoteHelper: this.getNodeIdRemoteHelper.bind(this),
       findSuccessorRemoteHelper: this.findSuccessorRemoteHelper.bind(this),
       getSuccessorRemoteHelper: this.getSuccessorRemoteHelper.bind(this),
+      setSuccessor: this.setSuccessor.bind(this),
       getPredecessor: this.getPredecessor.bind(this),
       setPredecessor: this.setPredecessor.bind(this),
       closestPrecedingFingerRemoteHelper: this.closestPrecedingFingerRemoteHelper.bind(
         this
       ),
       updateFingerTable: this.updateFingerTable.bind(this),
-      notify: this.notify.bind(this)
+      notify: this.notify.bind(this),
+      destructor: this.destructor.bind(this)
     });
 
     // We assume that binding to 0.0.0.0 indeed makes us accessible at this.host

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -117,7 +117,7 @@ export class UserService extends ChordNode {
       console.error("remove: findSuccessor failed with ", err);
     }
 
-    if (this.iAmTheSuccessor(successor)) {
+    if (this.iAmTheNode(successor)) {
       if (DEBUGGING_LOCAL) console.log("remove: remove user from local node");
       const err = this.removeUser(userId);
       callback(err, {});
@@ -187,7 +187,7 @@ export class UserService extends ChordNode {
       console.error("insert: findSuccessor failed with ", err);
     }
 
-    if (this.iAmTheSuccessor(successor)) {
+    if (this.iAmTheNode(successor)) {
       if (DEBUGGING_LOCAL) console.log("insert: insert user to local node");
       const err = this.insertUser(userEdit);
       callback(err, {});
@@ -257,7 +257,7 @@ export class UserService extends ChordNode {
       console.error("lookup: findSuccessor failed with ", err);
     }
 
-    if (this.iAmTheSuccessor(successor)) {
+    if (this.iAmTheNode(successor)) {
       if (DEBUGGING_LOCAL) console.log("lookup: lookup user to local node");
       const { err, user } = this.lookupUser(userId);
       if (DEBUGGING_LOCAL)

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -24,6 +24,7 @@ service Node {
   rpc getNodeIdRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc findSuccessorRemoteHelper (RemoteId) returns (NodeAddress) {}
   rpc getSuccessorRemoteHelper (NodeAddress) returns (NodeAddress) {}
+  rpc setSuccessor (NodeAddress) returns (google.protobuf.Empty) {}
   rpc getPredecessor (NodeAddress) returns (NodeAddress) {}
   rpc setPredecessor (NodeAddress) returns (google.protobuf.Empty) {}
   rpc closestPrecedingFingerRemoteHelper (RemoteId) returns (NodeAddress) {}


### PR DESCRIPTION
resolves #14  

I believe that this gracefully closes each node when issuing a SIGINT, such as with "ctrl + c" in Linux.  I haven't tested it on Windows but I assume that one of you can as part of the PR review.  The following driver can be used to test the functionality:

https://docs.google.com/document/d/1-eDUOk9IIgfan_f5wPR5F5QxLV9QTqotmLd4hP_i7A8/edit?usp=sharing

Basically, I created a "destructor()" method within ChordNode.  That method performs the following steps:

1- tries to find a suitable successor

2- if one is found, attempts to migrate its keys to the successor - currently a dummy call to a new method called "migrateKeysBeforeDeparture()"

3- attempts to notify its predecessor about its new successor, and attempts to notify its successor about its new predecessor

4- kills the node's process

In order to support that, I created a new "setSuccessor()" method.  Both it and the destructor are bound in the UserService and are incorporated into the chord.proto.

Finally, an event handler is added to main() in node.ts to watch for SIGINT and call the destructor when that happens - see line 106 at https://github.com/bushidocodes/chord-grpc/blob/49599cdcfe373d8b51ed32dbd339e871dc7fe45e/app/node.ts#L106.

That's a handler for Linux that apparently also works on Windows 8 and 10.