### PR TITLE
43 investigate data hashing

### DIFF
--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -112,12 +112,12 @@ export class UserService extends ChordNode {
     const userId = message.request.id;
     let isPrimaryHash: boolean = true;
 
-    let err = await this.removeWithHash(userId, isPrimaryHash);
-    if (err) callback(err, {});
-
+    const err1 = await this.removeWithHash(userId, isPrimaryHash);
     isPrimaryHash = false;
-    err = await this.removeWithHash(userId, isPrimaryHash);
-    callback(err, {});
+    const err2 = await this.removeWithHash(userId, isPrimaryHash);
+
+    if (err1 && err2) callback(err1, {});
+    else callback(null, {});
   }
 
   async removeWithHash(userId: number, isPrimaryHash: boolean) {
@@ -205,12 +205,13 @@ export class UserService extends ChordNode {
     const userEdit = message.request;
     let isPrimaryHash: boolean = true;
 
-    let err = await this.insertWithHash(userEdit, isPrimaryHash);
-    if (err) callback(err, {});
+    const err1 = await this.insertWithHash(userEdit, isPrimaryHash);
 
     isPrimaryHash = false;
-    err = await this.insertWithHash(userEdit, isPrimaryHash);
-    callback(err, {});
+    const err2 = await this.insertWithHash(userEdit, isPrimaryHash);
+
+    if (err1 && err2) callback(err1, {});
+    else callback(null, {});
   }
 
   async insertWithHash(userEdit: any, isPrimaryHash: boolean) {

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -111,10 +111,23 @@ export class UserService extends ChordNode {
   async remove(message, callback) {
     const userId = message.request.id;
     let successor = NULL_NODE;
+    let lookupKey: number = null;
+    let errorString: string = null;
     console.log("remove: Attempting to remove user ", userId);
 
+    //compute primary user ID from hash
+    if (userId && userId !== null) {
+      lookupKey = await this.computeUserIdHashPrimary(userId);
+    } else {
+      errorString = `insert: error computing hash of ${userId}.`;
+      if (DEBUGGING_LOCAL) {
+        console.log(errorString);
+      }
+      throw new RangeError(errorString);
+    }
+
     try {
-      successor = await this.findSuccessor(userId, this.encapsulateSelf());
+      successor = await this.findSuccessor(lookupKey, this.encapsulateSelf());
     } catch (err) {
       successor = NULL_NODE;
       console.error("remove: findSuccessor failed with ", err);


### PR DESCRIPTION
Resolves #43 
Resolves #12 

The first part of this PR was including hashing in the users. Naim did this piece.

The second part is fault tolerant data storage. This has been done the following way:
- When a user is inserted, the userId is hashed in two different ways. The idea is to get to different keys so that the user is inserted in two different nodes
- When a user is looked up, hash1 will be used first, if the user is not found hash2 is used. If still the user is not found lookup returns not found
- Remove will attempt to remove the user in the two nodes obtained from the two different keys

Some scenarios I am handling:
- If the hashes returned by insert lead to the same node, I will only insert the user once and I'm not returning a duplicated user error in the client (it was doing it with the base funcitonality)
- If remove can only remove one of the two users, I am returning OK. I am doing this because there could be only one copy in the chord that is deleted successfully but as the second remove fails it would return user not removed.

This has at least one flaw, it could happen that the remove function fail due to a temporal connection, I return user deleted, and then one of the copies remains in the chord.

I believe there could be other scenarios I can't think of them right now, but I want to merge all this functionality before making it much more complicated.