### PR TITLE
Fix catch param shadowing outer migrationError in destructor()

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -1296,9 +1296,10 @@ export class ChordNode {
     if (successorSeemsOK) {
       try {
         migrationSeemsOK = await this.migrateKeysBeforeDeparture();
-      } catch (migrationError) {
+      } catch (err) {
         migrationSeemsOK = false;
-        console.error(migrationError);
+        migrationError = err;
+        console.error(err);
       }
     }
     // notify predecessor


### PR DESCRIPTION
## Summary

- In `destructor()`, the `catch` clause for the migration step used `catch (migrationError)`, which shadowed the outer `let migrationError = null` declaration.
- As a result, the outer variable was never assigned, and the final diagnostic log always printed `null` instead of the real exception.
- Fix: renamed the catch parameter to `err`, assigned `migrationError = err`, so the outer variable is populated before the error branch logs it.

## What changed

`app/ChordNode.ts` — one catch block in `destructor()`:
- `catch (migrationError)` → `catch (err)`  
- Added `migrationError = err` to populate the outer binding
- `console.error(migrationError)` → `console.error(err)` (no behaviour change, just consistent naming)

## Reviewer notes

Pure bug fix — no logic changes beyond ensuring the error is surfaced in the shutdown diagnostic. Closes #130.