### PR TITLE
Hash synchronously on main thread (fixes worker-thread leak; refs #134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The `npm test` script is a placeholder that exits with an error.
 
 - **32-bit hash space**: SHA-1 truncated to `HASH_BIT_LENGTH=32` bits (configurable in `app/utils.ts`)
 - **Dual-hashing replication**: Each user stored at two nodes (primary + secondary hash) for fault tolerance
-- **Worker threads**: SHA-1 hashing offloaded to `app/cryptoThread.js` to avoid blocking
+- **Synchronous hashing**: SHA-1 of short strings runs on the main thread via Node's `crypto` (`sha1()` in `app/utils.ts`)
 - **Fibonacci finger tables**: Optional optimization via `FIBONACCI_ALPHA` constant
 - **Circular key space**: `isInModuloRange()` in `utils.ts` handles wraparound arithmetic
 

--- a/app/cryptoThread.js
+++ b/app/cryptoThread.js
@@ -1,5 +1,0 @@
-import crypto from "crypto";
-import { parentPort, workerData } from "worker_threads";
-parentPort.postMessage(
-  crypto.createHash("sha1").update(workerData).digest("hex"),
-);

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import process from "process";
-import { Worker } from "worker_threads";
+import crypto from "crypto";
 import * as grpc from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 
@@ -76,20 +76,12 @@ export function isInModuloRange(
 }
 
 /**
- * Creates a worker thread to execute crypto and returns a result.
- * To use `const result = await sha1("stuff2");`
+ * Computes the SHA-1 digest of the input as a lowercase hex string.
+ * Hashing a short string is a microsecond-scale, CPU-only operation, so it
+ * runs synchronously on the main thread.
  */
-export function sha1(source: String): Promise<String> {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(
-      path.join(import.meta.dirname, "./cryptoThread.js"),
-      {
-        workerData: source,
-      },
-    );
-    worker.on("message", resolve);
-    worker.on("error", reject);
-  });
+export function sha1(source: string): string {
+  return crypto.createHash("sha1").update(source).digest("hex");
 }
 
 /** Compute a hash of desired length for the input string.
@@ -112,7 +104,7 @@ export async function computeIntegerHash(
     );
     process.exit(-9);
   }
-  let hashOutput = await sha1(stringForHashing);
+  let hashOutput = sha1(stringForHashing);
   if (DEBUGGING_LOCAL)
     console.log(`Full hash of "${stringForHashing}" is ${hashOutput}.`);
   // truncate because JavaScript only does bitwise operations on 32-bit numbers


### PR DESCRIPTION
## Summary

Replaces the per-call worker thread used for SHA-1 hashing with Node's core `crypto` on the main thread.

`sha1()` previously spawned a `new Worker` for **every** hash and never called `worker.terminate()`, leaking a V8 isolate on every node join, insert, and lookup (`computeIntegerHash` / `computeHostPortHash` callers in `app/node.ts`, `app/UserService.ts`, `app/ChordNode.ts`). Spawning a worker (~milliseconds) to SHA-1 a short string (~microseconds synchronously) is also pathologically slow.

This also eliminates the worker message-passing path that [#134](https://github.com/bushidocodes/chord-grpc/issues/134) suspected of returning a non-string `hashOutput`.

## Changes

- `app/utils.ts` — `sha1()` now returns a primitive `string` synchronously via `crypto.createHash("sha1")`; dropped the `worker_threads` import in favor of `crypto`; fixed the boxed `String` → `string` typing; removed the now-unnecessary `await`.
- Deleted `app/cryptoThread.js` (no longer referenced).
- `CLAUDE.md` — updated the stale "Worker threads" design-decision note.

## On #134

I could **not** reproduce the reported `hashOutput.slice is not a function` crash. Running the exact code at HEAD in the reported environment (`node:24-alpine`, Node 24.16.0) — and on Windows — `sha1()` resolves with a primitive `string` and `.slice()` works; `computeIntegerHash("localhost:8440")` returns `30579573`. The report's "boxed `String` wrapper" hypothesis doesn't hold at runtime (TS type annotations are erased; `digest("hex")` structured-clones as a primitive string).

This PR is therefore framed as removing the genuine worker-thread leak/overhead rather than fixing a crash. It makes the suspected fragility impossible regardless of environment.

## Verification

- Digests unchanged before/after (`30579573` for `localhost:8440`).
- `npx tsc --noEmit` passes clean.
- Hashing exercised on Windows (Node 24.16.0) and in `node:24-alpine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)