### PR TITLE
Add error and end handlers to gRPC streams in web crawler

### DIFF
--- a/web/web.ts
+++ b/web/web.ts
@@ -116,15 +116,23 @@ class ChordCrawler {
         // Update Fingers
         const fingerTableStream = await this.#client.getFingerTableEntries();
         this.#state[connectionString].fingerTable = {};
-        fingerTableStream.on("data", ({ index, node }) => {
-          this.#state[connectionString].fingerTable[index] = node;
+        await new Promise<void>((resolve, reject) => {
+          fingerTableStream.on("data", ({ index, node }) => {
+            this.#state[connectionString].fingerTable[index] = node;
+          });
+          fingerTableStream.on("end", resolve);
+          fingerTableStream.on("error", reject);
         });
 
         // Update UserIds
         const userIdStream = await this.#client.getUserIds();
         this.#state[connectionString].userIds = [];
-        userIdStream.on("data", (idWithMetadata: any) => {
-          this.#state[connectionString].userIds.push(idWithMetadata);
+        await new Promise<void>((resolve, reject) => {
+          userIdStream.on("data", (idWithMetadata: any) => {
+            this.#state[connectionString].userIds.push(idWithMetadata);
+          });
+          userIdStream.on("end", resolve);
+          userIdStream.on("error", reject);
         });
 
         // Update Predecessor


### PR DESCRIPTION
## Summary

- Wraps `getFingerTableEntries` and `getUserIds` server-streaming calls in Promises with `end` and `error` handlers
- The crawl now **awaits** full stream completion before calling `#advance()` or proceeding to fetch successor/predecessor — eliminating the race where partial data was snapshotted
- Stream errors propagate to the existing `try/catch` block, which already handles unreachable nodes (code 14) and logs unexpected errors — no new error-handling logic needed

Closes #127

## Test plan

- [ ] Start a multi-node cluster (`docker-compose up --scale node_secondary=5 -d`) and confirm the web UI at `/data` shows complete finger tables for each node
- [ ] Kill a node mid-crawl and confirm the web UI recovers (node removed from state, crawl continues from another node) without silent partial data

🤖 Generated with [Claude Code](https://claude.com/claude-code)