### PR TITLE
Remove stale TODO comments from updateFingerTable() RPC handler

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -817,14 +817,10 @@ export class ChordNode {
           `updateFingerTable: Updated {${this.id}}.fingerTable[${fingerIndex}] to ${sNode}`,
         );
 
-      // TODO: Figure out how to determine if the above had an RC of 0
-      // If so call callback({status: 0, message: "OK"}, {});
       callback(null, {});
       return;
     }
 
-    // TODO: Figure out how to determine if the above had an RC of 0
-    //callback({ status: 0, message: "OK" }, {});
     callback(null, {});
   }
 


### PR DESCRIPTION
## Summary

- Removes two stale `// TODO` comment blocks from `updateFingerTable()` in `ChordNode.ts`
- Removes the commented-out incorrect callback invocation (`callback({ status: 0, message: "OK" }, {})`) which misunderstood the gRPC-js API
- The correct success callback `callback(null, {})` was already present; this PR just cleans up the noise around it

The `@grpc/grpc-js` unary callback signature is `(error: ServiceError | null, response) => void` — passing `null` as the first arg signals success. The `{status, message}` form was left over from an earlier misread of the API.

Closes #125

## Test plan

- [ ] Verify `updateFingerTable` RPC still functions correctly in a running cluster (`docker-compose up --scale node_secondary=5`)
- [ ] Confirm TypeScript compiles without errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)