### PR TITLE
Replace CDN-loaded lodash and vis-network with local vendor copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .claude/
+web/public/vendor/

--- a/WebDockerfile
+++ b/WebDockerfile
@@ -5,5 +5,6 @@ WORKDIR /home/node
 COPY --chown=node:node package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY --chown=node:node . .
+RUN pnpm run copyVendor
 EXPOSE 1337
 CMD [ "node", "./web/web.ts"]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "web": "node ./web/web.ts",
     "devServer": "node --watch ./app/node.ts",
     "devWeb": "node --watch ./web/web.ts",
+    "copyVendor": "node ./scripts/copy-vendor.js",
+    "postinstall": "node ./scripts/copy-vendor.js",
     "prepare": "husky"
   },
   "author": "",
@@ -32,10 +34,12 @@
     "@types/express": "^5.0.0",
     "@types/minimist": "^1.2.5",
     "@types/xml2js": "^0.4.14",
-    "xml2js": "^0.6.0",
     "husky": "^9.0.0",
+    "lodash": "^4.18.1",
     "prettier": "^3.0.0",
     "pretty-quick": "^4.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vis-network": "^10.1.0",
+    "xml2js": "^0.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       husky:
         specifier: ^9.0.0
         version: 9.1.7
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
       prettier:
         specifier: ^3.0.0
         version: 3.8.3
@@ -41,11 +44,21 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      vis-network:
+        specifier: ^10.1.0
+        version: 10.1.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@8.0.4(uuid@14.0.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)))(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0))
       xml2js:
         specifier: ^0.6.0
         version: 0.6.2
 
 packages:
+  "@egjs/hammerjs@2.0.17":
+    resolution:
+      {
+        integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==,
+      }
+    engines: { node: ">=0.8.0" }
+
   "@grpc/grpc-js@1.14.4":
     resolution:
       {
@@ -164,6 +177,12 @@ packages:
     resolution:
       {
         integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
+      }
+
+  "@types/hammerjs@2.0.46":
+    resolution:
+      {
+        integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==,
       }
 
   "@types/http-errors@2.0.5":
@@ -288,6 +307,13 @@ packages:
       {
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
+
+  component-emitter@2.0.0:
+    resolution:
+      {
+        integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==,
+      }
+    engines: { node: ">=18" }
 
   content-disposition@0.5.4:
     resolution:
@@ -533,10 +559,22 @@ packages:
       }
     engines: { node: ">=8" }
 
+  keycharm@0.4.0:
+    resolution:
+      {
+        integrity: sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==,
+      }
+
   lodash.camelcase@4.3.0:
     resolution:
       {
         integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
+      }
+
+  lodash@4.18.1:
+    resolution:
+      {
+        integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
 
   long@5.3.2:
@@ -868,12 +906,51 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
+  uuid@14.0.0:
+    resolution:
+      {
+        integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==,
+      }
+    hasBin: true
+
   vary@1.1.2:
     resolution:
       {
         integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
       }
     engines: { node: ">= 0.8" }
+
+  vis-data@8.0.4:
+    resolution:
+      {
+        integrity: sha512-TsN0sMHqIRpdfg6TNPtfdINpkgxtnQP6JNWCaiSwvou5seXqKiP5eERkaBg+Y56wyJ4FZTeOEs/dEmWEPrpltQ==,
+      }
+    peerDependencies:
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0
+      vis-util: ">=6.0.0"
+
+  vis-network@10.1.0:
+    resolution:
+      {
+        integrity: sha512-D7b5p/C6SwWv1BlH9EDdtP0Tje/PJzSBWKef9qy2DyTC14QB7KBcnAZxIyW2m7mFYyfoeR+k5GF747zDcIhaKA==,
+      }
+    peerDependencies:
+      "@egjs/hammerjs": ^2.0.0
+      component-emitter: ^1.3.0 || ^2.0.0
+      keycharm: ^0.2.0 || ^0.3.0 || ^0.4.0
+      uuid: ^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0
+      vis-data: ">=8.0.0"
+      vis-util: ">=6.0.0"
+
+  vis-util@6.0.0:
+    resolution:
+      {
+        integrity: sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==,
+      }
+    engines: { node: ">=8" }
+    peerDependencies:
+      "@egjs/hammerjs": ^2.0.0
+      component-emitter: ^1.3.0 || ^2.0.0
 
   wrap-ansi@7.0.0:
     resolution:
@@ -918,6 +995,10 @@ packages:
     engines: { node: ">=12" }
 
 snapshots:
+  "@egjs/hammerjs@2.0.17":
+    dependencies:
+      "@types/hammerjs": 2.0.46
+
   "@grpc/grpc-js@1.14.4":
     dependencies:
       "@grpc/proto-loader": 0.8.1
@@ -984,6 +1065,8 @@ snapshots:
       "@types/body-parser": 1.19.6
       "@types/express-serve-static-core": 5.1.1
       "@types/serve-static": 2.2.0
+
+  "@types/hammerjs@2.0.46": {}
 
   "@types/http-errors@2.0.5": {}
 
@@ -1063,6 +1146,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  component-emitter@2.0.0: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -1212,7 +1297,11 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  keycharm@0.4.0: {}
+
   lodash.camelcase@4.3.0: {}
+
+  lodash@4.18.1: {}
 
   long@5.3.2: {}
 
@@ -1398,7 +1487,28 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@14.0.0: {}
+
   vary@1.1.2: {}
+
+  vis-data@8.0.4(uuid@14.0.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)):
+    dependencies:
+      uuid: 14.0.0
+      vis-util: 6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)
+
+  vis-network@10.1.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@8.0.4(uuid@14.0.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)))(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)):
+    dependencies:
+      "@egjs/hammerjs": 2.0.17
+      component-emitter: 2.0.0
+      keycharm: 0.4.0
+      uuid: 14.0.0
+      vis-data: 8.0.4(uuid@14.0.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0))
+      vis-util: 6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0)
+
+  vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@2.0.0):
+    dependencies:
+      "@egjs/hammerjs": 2.0.17
+      component-emitter: 2.0.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/scripts/copy-vendor.js
+++ b/scripts/copy-vendor.js
@@ -1,0 +1,23 @@
+import { cpSync, mkdirSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dest = resolve(__dirname, "../web/public/vendor");
+
+mkdirSync(dest, { recursive: true });
+
+cpSync(
+  resolve(
+    __dirname,
+    "../node_modules/vis-network/standalone/umd/vis-network.min.js",
+  ),
+  resolve(dest, "vis-network.min.js"),
+);
+
+cpSync(
+  resolve(__dirname, "../node_modules/lodash/lodash.min.js"),
+  resolve(dest, "lodash.min.js"),
+);
+
+console.log("Vendor files copied to web/public/vendor/");

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Chord Network</title>
-    <script src="https://visjs.github.io/vis-network/dist/vis-network.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
+    <script src="./vendor/vis-network.min.js"></script>
+    <script src="./vendor/lodash.min.js"></script>
     <script src="./index.js"></script>
     <link rel="stylesheet" href="style.css" />
   </head>


### PR DESCRIPTION
## Summary

- Installs `lodash` and `vis-network` as `devDependencies`
- Adds `scripts/copy-vendor.js` which copies their minified UMD builds to `web/public/vendor/` at install time
- Wires the script as both a `postinstall` hook (local dev) and an explicit `RUN pnpm run copyVendor` step in `WebDockerfile` (Docker builds, which use `--ignore-scripts`)
- Updates `web/public/index.html` to load from `./vendor/` instead of CDN URLs
- Gitignores `web/public/vendor/` since it's a generated artifact

## Why

Both CDN script tags had issues flagged in #128:
- `vis-network` was loaded from `visjs.github.io` with no version pin — a CDN update could silently break the UI
- `lodash` was pinned to `4.17.15` on cdnjs but had no SRI `integrity=` hash
- Both fail in air-gapped environments or during CDN outages

This PR implements Option 2 from the issue: install as devDependencies and serve locally, which locks both libraries to the exact versions resolved in `pnpm-lock.yaml`.

## Reviewer notes

- The `postinstall` script covers the `pnpm install && devWeb` local workflow
- The explicit `RUN pnpm run copyVendor` in `WebDockerfile` covers the Docker build path (pnpm's `--ignore-scripts` would otherwise skip `postinstall`)
- For the docker-compose volume-mount case (`./web:/home/node/web`), vendor files come from the host via `postinstall` running during local `pnpm install`

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)