### PR TITLE
Fix double vendor copy in WebDockerfile

### DIFF
--- a/WebDockerfile
+++ b/WebDockerfile
@@ -5,6 +5,6 @@ WORKDIR /home/node
 COPY --chown=node:node package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY --chown=node:node . .
-RUN pnpm run copyVendor
+RUN node ./scripts/copy-vendor.js
 EXPOSE 1337
 CMD [ "node", "./web/web.ts"]


### PR DESCRIPTION
## Summary

- `pnpm run copyVendor` triggered pnpm's deferred lifecycle flush, causing `postinstall` to run first, then `copyVendor` — both run the same `copy-vendor.js` script, so vendor files were copied twice
- Replaced with `node ./scripts/copy-vendor.js` to call the script directly, bypassing pnpm's lifecycle deferral entirely and guaranteeing exactly one copy
- Keeps `--ignore-scripts` on the install step for supply-chain security

Fixes #143

## Test plan

- [ ] Build the Docker image with `docker build -f WebDockerfile .` and confirm the build log shows `copy-vendor.js` runs exactly once
- [ ] Verify `web/public/vendor/lodash.min.js` and `vis-network.min.js` are present in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)