### PR TITLE
Remove spurious -- separator from docker-compose pnpm run commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
       dockerfile: NodeDockerfile
     ports:
       - "8440:1337"
-    command: "pnpm run devServer -- --host node_primary --knownHost node_primary --knownPort 1337"
+    command: "pnpm run devServer --host node_primary --knownHost node_primary --knownPort 1337"
   node_secondary:
     build:
       context: .
       dockerfile: NodeDockerfile
-    command: "pnpm run devServer -- --knownHost node_primary --knownPort 1337"
+    command: "pnpm run devServer --knownHost node_primary --knownPort 1337"
     depends_on:
       - node_primary
   web:
@@ -24,4 +24,4 @@ services:
     volumes:
       - ./web:/home/node/web
       - /home/node/node_modules/
-    command: pnpm run devWeb -- --host node_primary --port 1337 --webPort 1337
+    command: "pnpm run devWeb --host node_primary --port 1337 --webPort 1337"


### PR DESCRIPTION
## Summary

- pnpm forwards arguments after the script name automatically — no `--` separator needed
- The bare `--` was being passed verbatim into `process.argv`, causing minimist to treat it as an end-of-options sentinel and silently discard all named flags (`--host`, `--port`, etc.) as positional args
- All three services (`node_primary`, `node_secondary`, `web`) were affected; the `web` container symptom was most visible (connecting to itself instead of `node_primary`)

Verified by running all three argument sets through `pnpm run` and confirming `process.argv` contains only the named flags with no `--` prefix.

Fixes #141

## Test plan

- [ ] `docker-compose up --scale node_secondary=2 -d` — web container should connect to `node_primary:1337` instead of looping on `<container-id>:undefined`
- [ ] Web UI at `http://localhost:1337` should show the overlay network

🤖 Generated with [Claude Code](https://claude.com/claude-code)