### PR TITLE
Prune nodes with invalid successors and reset crawler to seed

### DIFF
--- a/web/web.ts
+++ b/web/web.ts
@@ -11,6 +11,8 @@ const CRAWLER_INTERVAL_MS = 3000;
 class ChordCrawler {
   #host: string;
   #port: number;
+  #seedHost: string;
+  #seedPort: number;
   #client: any;
   #state: object = {};
   #walk: Set<any> = new Set([]);
@@ -23,6 +25,8 @@ class ChordCrawler {
   constructor(host: string, port: number, stepInMS: number) {
     this.#host = host;
     this.#port = port;
+    this.#seedHost = host;
+    this.#seedPort = port;
     this.#client = connect({ host: this.#host, port: this.#port });
     setInterval(async () => {
       await this.#crawl();
@@ -60,6 +64,12 @@ class ChordCrawler {
         this.#shuffleCurrentNode();
       }
     }
+  }
+
+  #resetToSeed() {
+    this.#host = this.#seedHost;
+    this.#port = this.#seedPort;
+    this.#walk.clear();
   }
 
   #shuffleCurrentNode() {
@@ -141,6 +151,15 @@ class ChordCrawler {
 
         // Update Successor
         const successorNode = await this.#client.getSuccessorRemoteHelper();
+        if (!successorNode.host || !successorNode.port) {
+          console.error(
+            `Node ${connectionString} returned invalid successor`,
+            `(host=${successorNode.host}, port=${successorNode.port}) — pruning and resetting to seed`,
+          );
+          delete this.#state[connectionString];
+          this.#resetToSeed();
+          return;
+        }
         this.#state[connectionString].successor = successorNode;
 
         // Advance to the successor or a known node in a partition

--- a/web/web.ts
+++ b/web/web.ts
@@ -166,11 +166,13 @@ class ChordCrawler {
         this.#advance();
       } catch (err) {
         if (err.code == 14) {
-          // If you can't reach a node, delete it and select a random node to continue walk
+          console.error(
+            `Node ${connectionString} is unreachable — pruning and resetting to seed`,
+          );
           delete this.#state[connectionString];
-          this.#shuffleCurrentNode();
+          this.#resetToSeed();
         } else {
-          console.log(err);
+          console.error(`Unexpected error crawling ${connectionString}:`, err);
         }
       } finally {
         this.#canAdvance = true;


### PR DESCRIPTION
## Summary

- When `getSuccessorRemoteHelper` returns a `NodeAddress` with a missing or zero-valued host/port, the crawler now logs an error, removes the offending node from state, and resets to the original seed node
- proto3 omits zero-valued fields on the wire; with `defaults: false` these arrive as `undefined`, with `defaults: true` (current config) they arrive as `""` / `0` — both falsy, both invalid crawl targets
- Previously the crawler silently fell through to `#advance()`, skipped the bad successor without logging, left the node in state, and did a random shuffle — which could leave the crawler stuck far from a working ring entry point
- Adds `#seedHost`/`#seedPort` fields (set from constructor args) and a `#resetToSeed()` method so recovery always returns to the known-good starting point

## How the bug was reproduced

A minimal gRPC server returning `NodeAddress { port: 0 }` (or `{}`) demonstrated that both `defaults: false` and `defaults: true` yield a falsy port on the receiver side — the guard is necessary regardless of the proto-loader setting.

Fixes #138

## Test plan

- [ ] Start cluster: `docker-compose up --scale node_secondary=2 -d`
- [ ] Confirm web UI shows all nodes normally (no regression)
- [ ] To trigger the error path: temporarily patch `getSuccessorRemoteHelper` in a node to return `{}`, confirm the web container logs `Node X returned invalid successor ... — pruning and resetting to seed` and continues crawling from `node_primary:1337`

🤖 Generated with [Claude Code](https://claude.com/claude-code)