### PR TITLE
Add fingerTable, predecessor, and successor CLI commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ npm run client -- edit --port 8440 --id 5 --displayName "Name" --reputation 99
 npm run client -- remove --port 8440 --id 5
 npm run client -- bulkInsert --path ./data/tinyUsers.json
 npm run client -- summary --port 8440
+
+# Ring topology inspection (useful for debugging ring formation / stale routing)
+npm run client -- fingerTable --port 8440   # print all finger table entries
+npm run client -- predecessor --port 8440   # print predecessor node
+npm run client -- successor --port 8440     # print successor node
 ```
 
 ### No test suite exists

--- a/client/client.ts
+++ b/client/client.ts
@@ -32,6 +32,15 @@ function main() {
       case "summary":
         client.summary();
         break;
+      case "fingerTable":
+        client.fingerTable();
+        break;
+      case "predecessor":
+        client.predecessor();
+        break;
+      case "successor":
+        client.successor();
+        break;
     }
   }
 }

--- a/client/common.ts
+++ b/client/common.ts
@@ -24,6 +24,58 @@ export class Client {
     }
   }
 
+  async fingerTable() {
+    try {
+      const summary = await this.client.summary({ id: 1 });
+      console.log(
+        `Finger table for node ${summary.id} (${summary.host}:${summary.port}):`,
+      );
+      const stream = this.client.getFingerTableEntries();
+      let i = 0;
+      await new Promise<void>((resolve, reject) => {
+        stream.on("data", ({ index, node }: { index: number; node: any }) => {
+          console.log(
+            `  [${i++}]  start=${index}  successor=${node.id} (${node.host}:${node.port})`,
+          );
+        });
+        stream.on("end", resolve);
+        stream.on("error", reject);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async predecessor() {
+    try {
+      const node = await this.client.getPredecessor();
+      if (!node || (!node.id && !node.host && !node.port)) {
+        console.log("No predecessor set");
+      } else {
+        console.log(
+          `Predecessor: id=${node.id}, host=${node.host}, port=${node.port}`,
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async successor() {
+    try {
+      const node = await this.client.getSuccessorRemoteHelper();
+      if (!node || (!node.id && !node.host && !node.port)) {
+        console.log("No successor set");
+      } else {
+        console.log(
+          `Successor: id=${node.id}, host=${node.host}, port=${node.port}`,
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   async lookup({ _, ...rest }) {
     if (!rest.id) {
       console.log("lookup requires an ID");


### PR DESCRIPTION
## Summary

- Adds `fingerTable` command that calls the existing `getFingerTableEntries` gRPC streaming RPC and prints each entry with its start value and successor node address
- Adds `predecessor` command that calls `getPredecessor` and prints the predecessor node
- Adds `successor` command that calls `getSuccessorRemoteHelper` and prints the successor node

Closes #139

## Usage

```
npm run client -- fingerTable --port 8445

Finger table for node 1046384311 (MANPUTER:8445):
  [0]  start=1046384312  successor=2091098561 (MANPUTER:8446)
  [1]  start=1046384313  successor=2091098561 (MANPUTER:8446)
  ...

npm run client -- predecessor --port 8445
Predecessor: id=500000000, host=MANPUTER, port=8444

npm run client -- successor --port 8445
Successor: id=2091098561, host=MANPUTER, port=8446
```

## Test plan

- [ ] Start a multi-node cluster (`docker-compose up --scale node_secondary=5 -d`)
- [ ] Run `npm run client -- fingerTable --port 8440` and confirm finger table entries print
- [ ] Run `npm run client -- predecessor --port 8440` and confirm predecessor node prints
- [ ] Run `npm run client -- successor --port 8440` and confirm successor node prints
- [ ] Run on a fresh single node and confirm predecessor shows "No predecessor set"

🤖 Generated with [Claude Code](https://claude.com/claude-code)