### PR TITLE
Replace DEBUGGING_LOCAL flag with pino structured logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,22 @@ npm run client -- predecessor --port 8440   # print predecessor node
 npm run client -- successor --port 8440     # print successor node
 ```
 
+### Logging
+
+Nodes use [pino](https://github.com/pinojs/pino) for structured JSON logging. Set `LOG_LEVEL` to control verbosity:
+
+```bash
+LOG_LEVEL=debug npm run devServer -- --port 8440   # verbose Chord protocol tracing
+LOG_LEVEL=info  npm run devServer -- --port 8440   # default: operations only
+LOG_LEVEL=warn  npm run devServer -- --port 8440   # warnings and errors only
+```
+
+For human-readable output during development, pipe through `pino-pretty`:
+
+```bash
+LOG_LEVEL=debug npm run devServer -- --port 8440 | npx pino-pretty
+```
+
 ### No test suite exists
 
 The `npm test` script is a placeholder that exits with an error.

--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -359,6 +359,7 @@ export class ChordNode {
       } catch (err) {
         nPreceding = NULL_NODE;
         handleGRPCErrors(
+          this.logger,
           "closestPrecedingFinger",
           "closestPrecedingFingerRemoteHelper",
           nodeQueried.host,
@@ -491,6 +492,7 @@ export class ChordNode {
       } catch (err) {
         knownNode.id = null;
         handleGRPCErrors(
+          this.logger,
           "joinCluster",
           "getNodeId",
           knownNode.host,
@@ -1149,6 +1151,7 @@ export class ChordNode {
           const _ = await predecessorClient.getPredecessor(this.id);
         } catch (err) {
           handleGRPCErrors(
+            this.logger,
             "checkPredecessor",
             "getPredecessor",
             this.predecessor.host,

--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -1,10 +1,11 @@
 import process from "process";
+import pino from "pino";
 import {
   connect,
   isInModuloRange,
   computeHostPortHash,
   handleGRPCErrors,
-  DEBUGGING_LOCAL,
+  createLogger,
   HASH_BIT_LENGTH,
   FIBONACCI_ALPHA,
   IS_FIBONACCI_CHORD,
@@ -28,6 +29,7 @@ export class ChordNode {
   id: number;
   host: string;
   port: number;
+  logger: pino.Logger;
   fingerTable: Array<FingerTableEntry> = [
     {
       start: null,
@@ -51,6 +53,7 @@ export class ChordNode {
     this.id = id;
     this.host = host;
     this.port = port;
+    this.logger = createLogger(host, port);
   }
 
   iAmTheNode(theNode: Node): boolean {
@@ -77,8 +80,8 @@ export class ChordNode {
    * Print Summary of state of node
    */
   summary(_: any, callback: (arg0: any, arg1: Node) => void) {
-    console.log("Summary: fingerTable: \n", this.fingerTable);
-    console.log("Summary: Predecessor: ", this.predecessor);
+    this.logger.info({ fingerTable: this.fingerTable }, "Summary: fingerTable");
+    this.logger.info({ predecessor: this.predecessor }, "Summary: Predecessor");
     callback(null, this.encapsulateSelf());
   }
 
@@ -94,28 +97,28 @@ export class ChordNode {
   async findSuccessor(id: number, nodeQueried: Node) {
     let nPrime = NULL_NODE;
     let nPrimeSuccessor = NULL_NODE;
-    if (DEBUGGING_LOCAL)
-      console.log(`findSuccessor: node queried {${nodeQueried.id}}.`);
+    this.logger.debug(`findSuccessor: node queried {${nodeQueried.id}}.`);
     if (this.id != undefined && this.iAmTheNode(nodeQueried)) {
       try {
         nPrime = await this.findPredecessor(id);
       } catch (err) {
-        console.error(`findSuccessor: findPredecessor failed with `, err);
+        this.logger.error({ err }, `findSuccessor: findPredecessor failed`);
         nPrime = NULL_NODE;
       }
 
-      if (DEBUGGING_LOCAL) console.log("findSuccessor: n' is ", nPrime.id);
+      this.logger.debug(`findSuccessor: n' is ${nPrime.id}`);
 
       try {
         nPrimeSuccessor = await this.getSuccessor(nPrime);
       } catch (err) {
-        console.error(`findSuccessor: call to getSuccessor failed with `, err);
+        this.logger.error(
+          { err },
+          `findSuccessor: call to getSuccessor failed`,
+        );
         nPrimeSuccessor = NULL_NODE;
       }
 
-      if (DEBUGGING_LOCAL) {
-        console.log("findSuccessor: n'.successor is ", nPrimeSuccessor.id);
-      }
+      this.logger.debug(`findSuccessor: n'.successor is ${nPrimeSuccessor.id}`);
     } else {
       const nodeQueriedClient = connect(nodeQueried);
       try {
@@ -126,6 +129,7 @@ export class ChordNode {
       } catch (err) {
         nPrimeSuccessor = NULL_NODE;
         handleGRPCErrors(
+          this.logger,
           "findSuccessor",
           "findSuccessorRemoteHelper",
           nodeQueried.host,
@@ -135,11 +139,9 @@ export class ChordNode {
       }
     }
 
-    if (DEBUGGING_LOCAL)
-      console.log(
-        "findSuccessor: departing n'.successor = ",
-        nPrimeSuccessor.id,
-      );
+    this.logger.debug(
+      `findSuccessor: departing n'.successor = ${nPrimeSuccessor.id}`,
+    );
     return nPrimeSuccessor;
   }
 
@@ -157,28 +159,25 @@ export class ChordNode {
     const id = idAndNodeQueried.request.id;
     const nodeQueried = idAndNodeQueried.request.node;
 
-    if (DEBUGGING_LOCAL)
-      console.log(
-        `findSuccessorRemoteHelper: id = ${id} nodeQueried = ${nodeQueried.id}.`,
-      );
+    this.logger.debug(
+      `findSuccessorRemoteHelper: id = ${id} nodeQueried = ${nodeQueried.id}.`,
+    );
 
     let nPrimeSuccessor = NULL_NODE;
     try {
       nPrimeSuccessor = await this.findSuccessor(id, nodeQueried);
     } catch (err) {
-      console.error(
-        "findSuccessorRemoteHelper: findSuccessor failed with",
-        err,
+      this.logger.error(
+        { err },
+        "findSuccessorRemoteHelper: findSuccessor failed",
       );
       nPrimeSuccessor = NULL_NODE;
     }
     callback(null, nPrimeSuccessor);
 
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        `findSuccessorRemoteHelper: nPrimeSuccessor = ${nPrimeSuccessor.id}`,
-      );
-    }
+    this.logger.debug(
+      `findSuccessorRemoteHelper: nPrimeSuccessor = ${nPrimeSuccessor.id}`,
+    );
   }
 
   /**
@@ -187,22 +186,20 @@ export class ChordNode {
    * @param {number} id the key sought
    */
   async findPredecessor(id: number) {
-    if (DEBUGGING_LOCAL) console.log("findPredecessor: id = ", id);
+    this.logger.debug(`findPredecessor: id = ${id}`);
 
     let nPrime = this.encapsulateSelf();
     let nPrimeSuccessor = NULL_NODE;
     try {
       nPrimeSuccessor = await this.getSuccessor(nPrime);
     } catch (err) {
-      console.error("findPredecessor: getSuccessor failed with", err);
+      this.logger.error({ err }, "findPredecessor: getSuccessor failed");
       nPrimeSuccessor = NULL_NODE;
     }
 
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        `findPredecessor: before while: nPrime = ${nPrime.id}; nPrimeSuccessor = ${nPrimeSuccessor.id}`,
-      );
-    }
+    this.logger.debug(
+      `findPredecessor: before while: nPrime = ${nPrime.id}; nPrimeSuccessor = ${nPrimeSuccessor.id}`,
+    );
 
     let iterationCounter = 2 ** HASH_BIT_LENGTH * HASH_BIT_LENGTH;
     while (
@@ -211,7 +208,7 @@ export class ChordNode {
       iterationCounter >= 0
     ) {
       // loop should exit if n' and its successor are the same
-      // loop should exit if thDe iterations are ridiculous
+      // loop should exit if the iterations are ridiculous
       // update loop protection
       iterationCounter--;
       try {
@@ -220,23 +217,23 @@ export class ChordNode {
         nPrime = NULL_NODE;
       }
 
-      if (DEBUGGING_LOCAL)
-        console.log(
-          `findPredecessor: At iterator ${iterationCounter} nPrime = ${nPrime}`,
-        );
+      this.logger.debug(
+        `findPredecessor: At iterator ${iterationCounter} nPrime = ${nPrime}`,
+      );
 
       try {
         nPrimeSuccessor = await this.getSuccessor(nPrime);
       } catch (err) {
-        console.error(
-          "findPredecessor call to getSuccessor (2) failed with",
-          err,
+        this.logger.error(
+          { err },
+          "findPredecessor: call to getSuccessor (2) failed",
         );
         nPrimeSuccessor = NULL_NODE;
       }
 
-      if (DEBUGGING_LOCAL)
-        console.log("findPredecessor: nPrimeSuccessor = ", nPrimeSuccessor);
+      this.logger.debug(
+        `findPredecessor: nPrimeSuccessor = ${nPrimeSuccessor.id}`,
+      );
     }
 
     return nPrime;
@@ -248,7 +245,7 @@ export class ChordNode {
    * @returns : the successor if the successor seems valid, or a null node otherwise
    */
   async getSuccessor(nodeQueried: Node) {
-    if (DEBUGGING_LOCAL) console.log(`getSuccessor(${nodeQueried.id})`);
+    this.logger.debug(`getSuccessor(${nodeQueried.id})`);
 
     // get n.successor either locally or remotely
     let nSuccessor = NULL_NODE;
@@ -264,6 +261,7 @@ export class ChordNode {
       } catch (err) {
         nSuccessor = { id: null, host: null, port: null };
         handleGRPCErrors(
+          this.logger,
           "getSuccessor",
           "getSuccessorRemoteHelper",
           nodeQueried.host,
@@ -273,10 +271,9 @@ export class ChordNode {
       }
     }
 
-    if (DEBUGGING_LOCAL)
-      console.log(
-        `getSuccessor: returning {${nodeQueried.id}}.successor = ${nSuccessor.id}`,
-      );
+    this.logger.debug(
+      `getSuccessor: returning {${nodeQueried.id}}.successor = ${nSuccessor.id}`,
+    );
 
     return nSuccessor;
   }
@@ -299,13 +296,13 @@ export class ChordNode {
     message: { request: any },
     callback: (arg0: any, arg1: {}) => void,
   ) {
-    if (DEBUGGING_LOCAL) {
-      console.log("setSuccessor: Self = ", this.encapsulateSelf());
-      console.log(
-        "setSuccessor: original successor = ",
-        this.fingerTable[0].successor.id,
-      );
-    }
+    this.logger.debug(
+      {
+        self: this.encapsulateSelf(),
+        originalSuccessor: this.fingerTable[0].successor.id,
+      },
+      "setSuccessor",
+    );
     const successorCandidate = message.request;
     if (
       successorCandidate.id !== null &&
@@ -314,11 +311,9 @@ export class ChordNode {
     ) {
       this.fingerTable[0].successor = successorCandidate;
     }
-    if (DEBUGGING_LOCAL)
-      console.log(
-        "setSuccessor: new successor = ",
-        this.fingerTable[0].successor.id,
-      );
+    this.logger.debug(
+      `setSuccessor: new successor = ${this.fingerTable[0].successor.id}`,
+    );
 
     callback(null, {});
   }
@@ -391,9 +386,9 @@ export class ChordNode {
     try {
       nPreceding = await this.closestPrecedingFinger(id, nodeQueried);
     } catch (err) {
-      console.error(
-        "closestPrecedingFingerRemoteHelper: closestPrecedingFinger failed with ",
-        err,
+      this.logger.error(
+        { err },
+        "closestPrecedingFingerRemoteHelper: closestPrecedingFinger failed",
       );
       nPreceding = NULL_NODE;
     }
@@ -427,22 +422,20 @@ export class ChordNode {
     message: { request: Node },
     callback: (arg0: any, arg1: {}) => void,
   ) {
-    if (DEBUGGING_LOCAL) {
-      console.log("setPredecessor: Self = ", this.encapsulateSelf());
-      console.log(
-        "setPredecessor: Self's original predecessor = ",
-        this.predecessor,
-      );
-    }
+    this.logger.debug(
+      {
+        self: this.encapsulateSelf(),
+        originalPredecessor: this.predecessor,
+      },
+      "setPredecessor",
+    );
 
     this.predecessor = message.request;
 
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        "setPredecessor: Self's new predecessor = ",
-        this.predecessor,
-      );
-    }
+    this.logger.debug(
+      { newPredecessor: this.predecessor },
+      "setPredecessor: updated",
+    );
 
     callback(null, {});
   }
@@ -514,9 +507,7 @@ export class ChordNode {
       if (this.iAmTheNode(possibleCollidingNode)) {
         // node collision
         errorString = `Error joining node "${this.host}:${this.port}" with ID {${this.id}} to node "${knownNode.host}:${knownNode.port}" because of a collision with node "${possibleCollidingNode.host}:${possibleCollidingNode.port}" having ID={${possibleCollidingNode.id}}.`;
-        if (DEBUGGING_LOCAL) {
-          console.log(errorString);
-        }
+        this.logger.error(errorString);
         throw new RangeError(errorString);
       }
       // now go ahead with the join
@@ -524,10 +515,8 @@ export class ChordNode {
       await this.updateOthers();
     } else {
       // the node doesn't exist so exit on error
-      errorString = `Error joining node "${this.host}:${this.port}" to node "${knownNode.host}:${knownNode.port}" because the latter can't be confirmed to exist.\n`;
-      if (DEBUGGING_LOCAL) {
-        console.log(errorString);
-      }
+      errorString = `Error joining node "${this.host}:${this.port}" to node "${knownNode.host}:${knownNode.port}" because the latter can't be confirmed to exist.`;
+      this.logger.error(errorString);
       throw new RangeError(errorString);
     }
 
@@ -535,10 +524,10 @@ export class ChordNode {
     this.successorTable[0] = this.fingerTable[0].successor;
 
     try {
-      if (DEBUGGING_LOCAL) console.log("join: calling migrateKys");
+      this.logger.debug("join: calling migrateKeys");
       await this.migrateKeysAfterJoining();
     } catch (error) {
-      console.error("Migrate keys failed with error:", error);
+      this.logger.error({ err: error }, "Migrate keys failed");
     }
 
     // And now that we've joined a cluster, we need maintain our state
@@ -548,17 +537,13 @@ export class ChordNode {
     setInterval(this.fixFingers.bind(this), 3000);
     setInterval(this.checkPredecessor.bind(this), 1000);
 
-    if (DEBUGGING_LOCAL) {
-      console.log(">>>>>     joinCluster          ");
-      console.log(
-        `The fingerTable[] leaving {${this.id}}.joinCluster(${knownNode.id}) is:\n`,
-        this.fingerTable,
-      );
-      console.log(
-        `The {${this.id}}.predecessor leaving joinCluster() is ${this.predecessor.id}`,
-      );
-      console.log("          joinCluster     <<<<<\n");
-    }
+    this.logger.debug(
+      {
+        fingerTable: this.fingerTable,
+        predecessor: this.predecessor.id,
+      },
+      `joinCluster: {${this.id}}.joinCluster(${knownNode.id}) complete`,
+    );
   }
 
   /**
@@ -572,9 +557,9 @@ export class ChordNode {
       nodeId = await this.getNodeId(knownNode);
     } catch (err) {
       nodeId = null;
-      console.error(
-        `Error confirming existence of node "${knownNode.host}:${knownNode.port}"\n`,
-        err,
+      this.logger.error(
+        { err },
+        `Error confirming existence of node "${knownNode.host}:${knownNode.port}"`,
       );
     }
     if (nodeId !== null && nodeId >= 0) {
@@ -606,12 +591,10 @@ export class ChordNode {
         nodeId = knownNodeObject.id;
       } catch (err) {
         nodeId = null;
-        if (DEBUGGING_LOCAL) {
-          console.error(
-            `Error getting ID of node "${knownNode.host}:${knownNode.port}"\n`,
-            err,
-          );
-        }
+        this.logger.debug(
+          { err },
+          `Error getting ID of node "${knownNode.host}:${knownNode.port}"`,
+        );
       }
     }
     return nodeId;
@@ -634,11 +617,9 @@ export class ChordNode {
    * Directly implement the pseudocode's initFingerTable() method.
    */
   async initFingerTable(nPrime: Node) {
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        `initFingerTable: self = ${this.id}; self.successor = ${this.fingerTable[0].successor.id}; finger[0].start = ${this.fingerTable[0].start} n' = ${nPrime.id}`,
-      );
-    }
+    this.logger.debug(
+      `initFingerTable: self = ${this.id}; self.successor = ${this.fingerTable[0].successor.id}; finger[0].start = ${this.fingerTable[0].start} n' = ${nPrime.id}`,
+    );
 
     let nPrimeSuccessor = NULL_NODE;
     try {
@@ -648,15 +629,14 @@ export class ChordNode {
       );
     } catch (err) {
       nPrimeSuccessor = NULL_NODE;
-      console.error("initFingerTable: findSuccessor failed with ", err);
+      this.logger.error({ err }, "initFingerTable: findSuccessor failed");
     }
     this.fingerTable[0].successor = nPrimeSuccessor;
 
-    if (DEBUGGING_LOCAL)
-      console.log(
-        "initFingerTable: n'.successor (now  self.successor) = ",
-        nPrimeSuccessor,
-      );
+    this.logger.debug(
+      { nPrimeSuccessor },
+      "initFingerTable: n'.successor (now self.successor)",
+    );
 
     let successorClient = connect(this.fingerTable[0].successor);
     try {
@@ -666,6 +646,7 @@ export class ChordNode {
     } catch (err) {
       this.predecessor = NULL_NODE;
       handleGRPCErrors(
+        this.logger,
         "initFingerTable",
         "getPredecessor",
         this.fingerTable[0].successor.host,
@@ -677,6 +658,7 @@ export class ChordNode {
       await successorClient.setPredecessor(this.encapsulateSelf());
     } catch (err) {
       handleGRPCErrors(
+        this.logger,
         "initFingerTable",
         "setPredecessor",
         this.fingerTable[0].successor.host,
@@ -685,8 +667,10 @@ export class ChordNode {
       );
     }
 
-    if (DEBUGGING_LOCAL)
-      console.log("initFingerTable: predecessor  ", this.predecessor);
+    this.logger.debug(
+      { predecessor: this.predecessor },
+      "initFingerTable: predecessor",
+    );
 
     for (let i = 0; i < this.fingerTable.length - 1; i++) {
       if (
@@ -707,19 +691,21 @@ export class ChordNode {
           );
         } catch (err) {
           this.fingerTable[i + 1].successor = NULL_NODE;
-          console.error("initFingerTable: findSuccessor() failed with ", err);
+          this.logger.error({ err }, "initFingerTable: findSuccessor() failed");
         }
       }
     }
-    if (DEBUGGING_LOCAL)
-      console.log("initFingerTable: fingerTable[] =\n", this.fingerTable);
+    this.logger.debug(
+      { fingerTable: this.fingerTable },
+      "initFingerTable: fingerTable[]",
+    );
   }
 
   /**
    * Directly implement the pseudocode's updateOthers() method.
    */
   async updateOthers() {
-    if (DEBUGGING_LOCAL) console.log("updateOthers");
+    this.logger.debug("updateOthers");
     let pNodeSearchID: number,
       pNodeClient: {
         updateFingerTable: (arg0: { node: Node; index: number }) => any;
@@ -729,22 +715,21 @@ export class ChordNode {
     for (let i = 0; i < this.fingerTable.length; i++) {
       pNodeSearchID =
         (this.id - 2 ** i + 2 ** HASH_BIT_LENGTH) % 2 ** HASH_BIT_LENGTH;
-      if (DEBUGGING_LOCAL)
-        console.log(
-          `updateOthers: i = ${i}; findPredecessor(${pNodeSearchID}) --> pNode`,
-        );
+      this.logger.debug(
+        `updateOthers: i = ${i}; findPredecessor(${pNodeSearchID}) --> pNode`,
+      );
 
       try {
         pNode = await this.findPredecessor(pNodeSearchID);
       } catch (err) {
         pNode = NULL_NODE;
-        console.error(
-          `updateOthers: Error from findPredecessor(${pNodeSearchID}) in updateOthers().`,
-          err,
+        this.logger.error(
+          { err },
+          `updateOthers: Error from findPredecessor(${pNodeSearchID})`,
         );
       }
 
-      if (DEBUGGING_LOCAL) console.log("updateOthers: pNode = ", pNode);
+      this.logger.debug(`updateOthers: pNode = ${pNode?.id}`);
 
       if (this.id !== pNode.id) {
         pNodeClient = connect(pNode);
@@ -755,6 +740,7 @@ export class ChordNode {
           });
         } catch (err) {
           handleGRPCErrors(
+            this.logger,
             "updateOthers",
             "updateFingerTable",
             pNode.host,
@@ -776,15 +762,14 @@ export class ChordNode {
     const sNode = message.request.node;
     const fingerIndex = message.request.index;
 
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        `updateFingerTable: {${this.id}}.fingerTable[] =\n`,
-        this.fingerTable,
-      );
-      console.log(
-        `updateFingerTable: sNode = ${message.request.node.id}; fingerIndex =${fingerIndex}`,
-      );
-    }
+    this.logger.debug(
+      {
+        fingerTable: this.fingerTable,
+        sNodeId: message.request.node.id,
+        fingerIndex,
+      },
+      "updateFingerTable",
+    );
 
     if (
       isInModuloRange(
@@ -804,6 +789,7 @@ export class ChordNode {
         });
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
           "updateFingerTable",
           "updateFingerTable",
           this.predecessor.host,
@@ -812,10 +798,9 @@ export class ChordNode {
         );
       }
 
-      if (DEBUGGING_LOCAL)
-        console.log(
-          `updateFingerTable: Updated {${this.id}}.fingerTable[${fingerIndex}] to ${sNode}`,
-        );
+      this.logger.debug(
+        `updateFingerTable: Updated {${this.id}}.fingerTable[${fingerIndex}] to ${sNode?.id}`,
+      );
 
       callback(null, {});
       return;
@@ -839,15 +824,13 @@ export class ChordNode {
    *
    */
   async updateSuccessorTable(): Promise<boolean> {
-    if (DEBUGGING_LOCAL) {
-      console.log(
-        `updateSuccessorTable: {${this.id}}.successorTable[] =\n`,
-        this.successorTable,
-      );
-      console.log(
-        `updateSuccessorTable: successor node id = ${this.fingerTable[0].successor.id}`,
-      );
-    }
+    this.logger.debug(
+      {
+        successorTable: this.successorTable,
+        successorId: this.fingerTable[0].successor.id,
+      },
+      `updateSuccessorTable: {${this.id}}`,
+    );
 
     // check whether the successor is available
     let successorSeemsOK = false;
@@ -855,7 +838,7 @@ export class ChordNode {
       successorSeemsOK = await this.isOkSuccessor();
     } catch (err) {
       successorSeemsOK = false;
-      console.error(`updateSuccessorTable: isOkSuccessor failed with `, err);
+      this.logger.error({ err }, `updateSuccessorTable: isOkSuccessor failed`);
     }
     if (successorSeemsOK) {
       // synchronize with finger table because its successor still seemed OK
@@ -868,9 +851,9 @@ export class ChordNode {
           successorSeemsOK = await this.isOkSuccessor();
         } catch (err) {
           successorSeemsOK = false;
-          console.error(
-            `updateSuccessorTable: isOkSuccessor failed with `,
-            err,
+          this.logger.error(
+            { err },
+            `updateSuccessorTable: isOkSuccessor failed`,
           );
         }
         if (successorSeemsOK) {
@@ -900,11 +883,9 @@ export class ChordNode {
       this.successorTable.length < SUCCESSOR_TABLE_MAX_LENGTH &&
       this.id !== this.fingerTable[0].successor.id
     ) {
-      if (DEBUGGING_LOCAL) {
-        console.log(
-          `updateSuccessorTable: Short successorTable[]: [ current length ${this.successorTable.length} ] < [ ${SUCCESSOR_TABLE_MAX_LENGTH} preferred length ]`,
-        );
-      }
+      this.logger.debug(
+        `updateSuccessorTable: Short successorTable[]: [ current length ${this.successorTable.length} ] < [ ${SUCCESSOR_TABLE_MAX_LENGTH} preferred length ]`,
+      );
       for (
         let i = 0;
         i < this.successorTable.length && i <= SUCCESSOR_TABLE_MAX_LENGTH;
@@ -913,13 +894,15 @@ export class ChordNode {
         try {
           successorSuccessor = await this.getSuccessor(this.successorTable[i]);
         } catch (err) {
-          console.error(`updateSuccessorTable: getSuccessor failed with `, err);
+          this.logger.error(
+            { err },
+            `updateSuccessorTable: getSuccessor failed`,
+          );
           successorSuccessor = { id: null, host: null, port: null };
         }
-        if (DEBUGGING_LOCAL)
-          console.log(
-            `updateSuccessorTable: {${this.id}}.successorTable[${i}] = ${this.successorTable[i].id} and {${this.successorTable[i].id}}.successor[0] = ${successorSuccessor.id}`,
-          );
+        this.logger.debug(
+          `updateSuccessorTable: {${this.id}}.successorTable[${i}] = ${this.successorTable[i].id} and {${this.successorTable[i].id}}.successor[0] = ${successorSuccessor.id}`,
+        );
 
         if (
           successorSuccessor &&
@@ -949,9 +932,9 @@ export class ChordNode {
       try {
         successorSeemsOK = await this.confirmExist(this.successorTable[i]);
       } catch (err) {
-        console.error(
-          `updateSuccessorTable: call to confirmExist failed with `,
-          err,
+        this.logger.error(
+          { err },
+          `updateSuccessorTable: call to confirmExist failed`,
         );
         successorSeemsOK = false;
       }
@@ -962,11 +945,10 @@ export class ChordNode {
       i -= 1;
     }
 
-    if (DEBUGGING_LOCAL)
-      console.log(
-        `updateSuccessorTable: new {${this.id}}.successorTable[] =\n`,
-        this.successorTable,
-      );
+    this.logger.debug(
+      { successorTable: this.successorTable },
+      `updateSuccessorTable: new {${this.id}}.successorTable[]`,
+    );
 
     return successorSeemsOK;
   }
@@ -996,9 +978,9 @@ export class ChordNode {
         try {
           successorClient = connect(this.fingerTable[0].successor);
         } catch (err) {
-          console.error(
-            `stabilize: call to connect {${this.fingerTable[0].successor.id}} failed with `,
-            err,
+          this.logger.error(
+            { err },
+            `stabilize: call to connect {${this.fingerTable[0].successor.id}} failed`,
           );
           this.stabilizeIsLocked = false;
           return false;
@@ -1010,6 +992,7 @@ export class ChordNode {
         } catch (err) {
           x = this.encapsulateSelf();
           handleGRPCErrors(
+            this.logger,
             "stabilize",
             "getPredecessor",
             this.fingerTable[0].successor.host,
@@ -1031,14 +1014,14 @@ export class ChordNode {
         this.fingerTable[0].successor = x;
       }
 
-      if (DEBUGGING_LOCAL) {
-        console.log(
-          `\nstabilize: leaving stabilize()`,
-          `\n\t{${this.id}}.predecessor = ${this.predecessor.id}`,
-          `\n\t{${this.id}}.fingerTable[] is:\n${this.fingerTable}`,
-          `\n\t{${this.id}}.successorTable[] is:\n${this.successorTable}\n`,
-        );
-      }
+      this.logger.debug(
+        {
+          predecessor: this.predecessor.id,
+          fingerTable: this.fingerTable,
+          successorTable: this.successorTable,
+        },
+        `stabilize: leaving stabilize()`,
+      );
 
       if (!this.iAmMyOwnSuccessor()) {
         try {
@@ -1046,6 +1029,7 @@ export class ChordNode {
           await successorClient.notify(this.encapsulateSelf());
         } catch (err) {
           handleGRPCErrors(
+            this.logger,
             "stabilize",
             "successorClient",
             this.fingerTable[0].successor.host,
@@ -1059,16 +1043,12 @@ export class ChordNode {
       try {
         await this.updateSuccessorTable();
       } catch (err) {
-        console.error(`stabilize: updateSuccessorTable failed with `, err);
+        this.logger.error({ err }, `stabilize: updateSuccessorTable failed`);
       }
 
-      // set to (1) to use as debugging tells
-      if (DEBUGGING_LOCAL) {
-        console.log(`--\n{${this.id}}.predecessor = ${this.predecessor.id}`);
-        console.log(
-          `{${this.id}}.successor = ${this.fingerTable[0].successor.id}`,
-        );
-      }
+      this.logger.debug(
+        `stabilize: {${this.id}}.predecessor = ${this.predecessor.id}; successor = ${this.fingerTable[0].successor.id}`,
+      );
       this.stabilizeIsLocked = false;
       return true;
     }
@@ -1094,7 +1074,7 @@ export class ChordNode {
         predecessorSeemsOK = await this.checkPredecessor();
       } catch (err) {
         predecessorSeemsOK = false;
-        console.error(`stabilizeSelf: checkPredecessor failed with `, err);
+        this.logger.error({ err }, `stabilizeSelf: checkPredecessor failed`);
       }
       if (predecessorSeemsOK) {
         // then kick by setting the successor to the same as the predecessor
@@ -1102,10 +1082,9 @@ export class ChordNode {
         this.successorTable[0] = this.fingerTable[0].successor;
       }
     } else {
-      if (DEBUGGING_LOCAL)
-        console.log(
-          `stabilizeSelf: Warning: {${this.id}} is isolated because predecessor is ${this.predecessor.id} and successor is ${this.fingerTable[0].successor.id}.`,
-        );
+      this.logger.debug(
+        `stabilizeSelf: Warning: {${this.id}} is isolated because predecessor is ${this.predecessor.id} and successor is ${this.fingerTable[0].successor.id}.`,
+      );
       predecessorSeemsOK = true;
     }
     return predecessorSeemsOK;
@@ -1144,16 +1123,11 @@ export class ChordNode {
           this.fingerTable[this.fingerToFix].successor = nSuccessor;
         }
       } catch (err) {
-        console.error(`fixFingers: findSuccessor failed with `, err);
+        this.logger.error({ err }, `fixFingers: findSuccessor failed`);
       }
-      if (DEBUGGING_LOCAL) {
-        console.log(
-          `fixFingers: Fix {${this.id}}.fingerTable[${this.fingerToFix}], with start = ${this.fingerTable[this.fingerToFix].start}.`,
-        );
-        console.log(
-          `fixFingers: fingerTable[${this.fingerToFix}] = ${this.fingerTable[this.fingerToFix].successor}`,
-        );
-      }
+      this.logger.debug(
+        `fixFingers: Fix {${this.id}}.fingerTable[${this.fingerToFix}], with start = ${this.fingerTable[this.fingerToFix].start}; successor = ${this.fingerTable[this.fingerToFix].successor?.id}`,
+      );
       if (this.fingerToFix < this.fingerTable.length - 1) {
         this.fingerToFix++;
       } else {
@@ -1196,10 +1170,9 @@ export class ChordNode {
    * Checks whether the successor is still responding.
    */
   async isOkSuccessor() {
-    if (DEBUGGING_LOCAL)
-      console.log(
-        `{${this.id}}.isOkSuccessor(${this.fingerTable[0].successor.id})`,
-      );
+    this.logger.debug(
+      `{${this.id}}.isOkSuccessor(${this.fingerTable[0].successor.id})`,
+    );
 
     let successorSeemsOK = false;
     if (this.fingerTable[0].successor.id == null) {
@@ -1214,9 +1187,9 @@ export class ChordNode {
         );
       } catch (err) {
         successorSeemsOK = false;
-        console.log(
-          `Error in isOkSuccessor({${this.id}}) call to confirmExist({${this.fingerTable[0].successor.id}})`,
-          err,
+        this.logger.error(
+          { err },
+          `isOkSuccessor({${this.id}}): call to confirmExist({${this.fingerTable[0].successor.id}}) failed`,
         );
       }
     }
@@ -1243,9 +1216,9 @@ export class ChordNode {
           successorSeemsOK = await this.confirmExist(this.successorTable[i]);
         } catch (err) {
           successorSeemsOK = false;
-          console.log(
-            `Error in destructor({${this.id}}) call to confirmExist({${this.successorTable[i].id}})\n`,
-            err,
+          this.logger.error(
+            { err },
+            `destructor({${this.id}}): call to confirmExist({${this.successorTable[i].id}}) failed`,
           );
         }
         successor = this.successorTable[i];
@@ -1266,9 +1239,9 @@ export class ChordNode {
           );
         } catch (err) {
           successorSeemsOK = false;
-          console.log(
-            `Error in destructor({${this.id}}) call to confirmExist({${this.fingerTable[i].successor.id}})\n`,
-            err,
+          this.logger.error(
+            { err },
+            `destructor({${this.id}}): call to confirmExist({${this.fingerTable[i].successor.id}}) failed`,
           );
         }
         successor = this.fingerTable[i].successor;
@@ -1280,9 +1253,9 @@ export class ChordNode {
         successorSeemsOK = await this.confirmExist(this.predecessor);
       } catch (err) {
         successorSeemsOK = false;
-        console.log(
-          `Error in destructor({${this.id}}) call to confirmExist({${this.predecessor}})\n`,
-          err,
+        this.logger.error(
+          { err },
+          `destructor({${this.id}}): call to confirmExist({${this.predecessor?.id}}) failed`,
         );
       }
       successor = this.predecessor;
@@ -1295,7 +1268,10 @@ export class ChordNode {
       } catch (err) {
         migrationSeemsOK = false;
         migrationError = err;
-        console.error(err);
+        this.logger.error(
+          { err },
+          "destructor: migrateKeysBeforeDeparture failed",
+        );
       }
     }
     // notify predecessor
@@ -1305,8 +1281,9 @@ export class ChordNode {
         await predecessorClient.setSuccessor(successor);
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
+          "destructor",
           "setSuccessor",
-          "predecessorClient",
           this.fingerTable[0].successor.host,
           this.fingerTable[0].successor.port,
           err,
@@ -1320,8 +1297,9 @@ export class ChordNode {
         await successorClient.setPredecessor(this.predecessor);
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
+          "destructor",
           "setPredecessor",
-          "successorClient",
           successor.host,
           successor.port,
           err,
@@ -1329,19 +1307,19 @@ export class ChordNode {
       }
     }
     // report what's up and destroy the node by exiting the process
-    console.log(
-      `\n\nNode {${this.id}} at "${this.host}:${this.port}" is exiting the chord.`,
+    this.logger.info(
+      `Node {${this.id}} at "${this.host}:${this.port}" is exiting the chord.`,
     );
     if (successorSeemsOK && migrationSeemsOK) {
-      console.log(`Its keys are migrating to node {${successor.id}}.\n`);
+      this.logger.info(`Keys are migrating to node {${successor.id}}.`);
     } else if (!successorSeemsOK) {
-      console.log(
-        `Its keys are not migrating because a successor couldn't be contacted.\n`,
+      this.logger.warn(
+        `Keys are not migrating because a successor couldn't be contacted.`,
       );
     } else if (!migrationSeemsOK) {
-      console.log(
-        `Its keys are not migrating because the migration failed with error:\n`,
-        migrationError,
+      this.logger.error(
+        { err: migrationError },
+        `Keys are not migrating because the migration failed.`,
       );
     }
     process.exit(0);

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -6,7 +6,6 @@ import { loadSync } from "@grpc/proto-loader";
 import { ChordNode } from "./ChordNode.ts";
 import {
   connect,
-  DEBUGGING_LOCAL,
   handleGRPCErrors,
   isInModuloRange,
   NULL_NODE,
@@ -86,13 +85,13 @@ export class UserService extends ChordNode {
     });
 
     // We assume that binding to 0.0.0.0 indeed makes us accessible at this.host
-    console.log(`Serving on ${this.host}:${this.port}`);
+    this.logger.info(`Serving on ${this.host}:${this.port}`);
     server.bindAsync(
       `0.0.0.0:${this.port}`,
       grpc.ServerCredentials.createInsecure(),
       (err) => {
         if (err) {
-          console.error(`Failed to bind server: ${err.message}`);
+          this.logger.error({ err }, `Failed to bind server: ${err.message}`);
           process.exit(1);
         }
       },
@@ -118,10 +117,10 @@ export class UserService extends ChordNode {
   removeUser(hashedUserId: string | number) {
     if (this.userMap[hashedUserId]) {
       delete this.userMap[hashedUserId];
-      console.log("removeUser: user removed");
+      this.logger.info(`removeUser: user removed at hash ${hashedUserId}`);
       return null;
     } else {
-      console.log("removeUser, user DNE");
+      this.logger.warn(`removeUser: user not found at hash ${hashedUserId}`);
       return { code: 5 };
     }
   }
@@ -131,7 +130,7 @@ export class UserService extends ChordNode {
     message: { request: { id: any } },
     callback: (call: { code: number }, arg1: {}) => void,
   ) {
-    if (DEBUGGING_LOCAL) console.log("removeUserRemoteHelper: ", message);
+    this.logger.debug({ message }, "removeUserRemoteHelper");
     const err = this.removeUser(message.request.id);
     callback(err, {});
   }
@@ -153,7 +152,7 @@ export class UserService extends ChordNode {
     let successor = NULL_NODE;
     let lookupKey: number = null;
     let errorString: string = null;
-    console.log("remove: Attempting to remove user ", userId);
+    this.logger.info(`remove: Attempting to remove user ${userId}`);
 
     //compute primary user ID from hash
     if (userId && userId !== null) {
@@ -162,9 +161,7 @@ export class UserService extends ChordNode {
         : await this.computeUserIdHashSecondary(userId);
     } else {
       errorString = `insert: error computing hash of ${userId}.`;
-      if (DEBUGGING_LOCAL) {
-        console.log(errorString);
-      }
+      this.logger.error(errorString);
       throw new RangeError(errorString);
     }
 
@@ -172,17 +169,16 @@ export class UserService extends ChordNode {
       successor = await this.findSuccessor(lookupKey, this.encapsulateSelf());
     } catch (err) {
       successor = NULL_NODE;
-      console.error("remove: findSuccessor failed with ", err);
+      this.logger.error({ err }, "remove: findSuccessor failed");
     }
 
     if (this.iAmTheNode(successor)) {
-      if (DEBUGGING_LOCAL) console.log("remove: remove user from local node");
+      this.logger.debug("remove: removing user from local node");
       const err = this.removeUser(lookupKey);
       return err;
     } else {
       try {
-        if (DEBUGGING_LOCAL)
-          console.log("remove: remove user from remote node");
+        this.logger.debug("remove: removing user from remote node");
         const successorClient = connect(successor);
         await successorClient.removeUserRemoteHelper(
           { id: lookupKey },
@@ -192,6 +188,7 @@ export class UserService extends ChordNode {
         );
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
           "remove",
           "removeUserRemoteHelper",
           successor.host,
@@ -211,18 +208,18 @@ export class UserService extends ChordNode {
       ? clonedUserEdit.user.metadata.primaryHash
       : clonedUserEdit.user.metadata.secondaryHash;
 
-    if (DEBUGGING_LOCAL) console.log("insertUser: ", clonedUserEdit);
+    this.logger.debug({ clonedUserEdit }, "insertUser");
     const { user, edit } = clonedUserEdit;
 
     if (this.userMap[key] && !edit) {
-      console.log(`insertUser: user already exits at hash ${key}`);
+      this.logger.warn(`insertUser: user already exists at hash ${key}`);
       return { code: 6 };
     } else {
       this.userMap[key] = user;
       if (edit) {
-        console.log(`insertUser: Edited User ${user.id} at hash ${key}`);
+        this.logger.info(`insertUser: Edited User ${user.id} at hash ${key}`);
       } else {
-        console.log(`insertUser: Inserted User ${user.id} at hash ${key}`);
+        this.logger.info(`insertUser: Inserted User ${user.id} at hash ${key}`);
       }
       return null;
     }
@@ -233,7 +230,7 @@ export class UserService extends ChordNode {
     message: { request: any },
     callback: (call: { code: number }, arg1: {}) => void,
   ) {
-    if (DEBUGGING_LOCAL) console.log("insertUserRemoteHelper: ", message);
+    this.logger.debug({ message }, "insertUserRemoteHelper");
     const err = this.insertUser(message.request);
     callback(err, {});
   }
@@ -270,32 +267,38 @@ export class UserService extends ChordNode {
       : userEdit.user.metadata.secondaryHash;
     let successor = NULL_NODE;
 
-    console.log(`insert: Attempting to insert user ${user.id} at ${lookupKey}`);
-    if (DEBUGGING_LOCAL) console.log(user);
+    this.logger.info(
+      { userId: user.id, lookupKey },
+      `insert: Attempting to insert user ${user.id} at ${lookupKey}`,
+    );
     try {
       successor = await this.findSuccessor(lookupKey, this.encapsulateSelf());
     } catch (err) {
       successor = NULL_NODE;
-      console.error("insert: findSuccessor failed with ", err);
+      this.logger.error({ err }, "insert: findSuccessor failed");
     }
 
     if (this.iAmTheNode(successor)) {
-      if (DEBUGGING_LOCAL) console.log("insert: insert user to local node");
+      this.logger.debug("insert: inserting user to local node");
       const err = this.insertUser(userEdit);
       return err;
     } else {
       try {
-        console.log("insert: insert user to remote node", lookupKey);
+        this.logger.debug(
+          { lookupKey },
+          "insert: inserting user to remote node",
+        );
         const successorClient = connect(successor);
         await successorClient.insertUserRemoteHelper(
           userEdit,
           (err: any, _: any) => {
-            console.log("insert finishing");
+            this.logger.debug("insert finishing");
             return err;
           },
         );
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
           "insert",
           "insertUser",
           successor.host,
@@ -315,7 +318,7 @@ export class UserService extends ChordNode {
     const {
       request: { id },
     } = message;
-    console.log(`Requested User ${id}`);
+    this.logger.info(`fetch: Requested User ${id}`);
     if (!this.userMap[id]) {
       callback({ code: 5 }, null); // NOT_FOUND error
     } else {
@@ -327,11 +330,10 @@ export class UserService extends ChordNode {
   lookupUser(hashedUserId: number) {
     if (this.userMap[hashedUserId]) {
       const user = this.userMap[hashedUserId];
-      if (DEBUGGING_LOCAL)
-        console.log(`User ${user.id} found at ${hashedUserId}`);
+      this.logger.debug(`lookupUser: User ${user.id} found at ${hashedUserId}`);
       return { err: null, user };
     } else {
-      if (DEBUGGING_LOCAL) console.log(`User not found at ${hashedUserId}`);
+      this.logger.debug(`lookupUser: User not found at ${hashedUserId}`);
       return { err: { code: 5 }, user: null };
     }
   }
@@ -340,11 +342,12 @@ export class UserService extends ChordNode {
     message: { request: { id: any } },
     callback: (call: any, arg1: any) => void,
   ) {
-    if (DEBUGGING_LOCAL)
-      console.log("beginning lookupUserRemoteHelper: ", message.request.id);
+    this.logger.debug(
+      { id: message.request.id },
+      "beginning lookupUserRemoteHelper",
+    );
     const { err, user } = this.lookupUser(message.request.id);
-    if (DEBUGGING_LOCAL)
-      console.log("finishing lookupUserRemoteHelper: ", user);
+    this.logger.debug({ user }, "finishing lookupUserRemoteHelper");
     callback(err, user);
   }
 
@@ -353,7 +356,7 @@ export class UserService extends ChordNode {
     callback: (call: any, arg1: any) => void,
   ) {
     const userId = message.request.id;
-    console.log(`lookup: Looking up user ${userId}`);
+    this.logger.info(`lookup: Looking up user ${userId}`);
 
     // Try Primary Hash
     let userErrorResponse = await this.lookupWithHash(userId, true);
@@ -375,10 +378,8 @@ export class UserService extends ChordNode {
         ? await this.computeUserIdHashPrimary(userId)
         : await this.computeUserIdHashSecondary(userId);
     } else {
-      errorString = `insert: error computing hash of ${userId}.`;
-      if (DEBUGGING_LOCAL) {
-        console.log(errorString);
-      }
+      errorString = `lookup: error computing hash of ${userId}.`;
+      this.logger.error(errorString);
       throw new RangeError(errorString);
     }
 
@@ -386,22 +387,17 @@ export class UserService extends ChordNode {
       successor = await this.findSuccessor(lookupKey, this.encapsulateSelf());
     } catch (err) {
       successor = NULL_NODE;
-      console.error("lookup: findSuccessor failed with ", err);
+      this.logger.error({ err }, "lookup: findSuccessor failed");
     }
 
     if (this.iAmTheNode(successor)) {
-      if (DEBUGGING_LOCAL) console.log("lookup: lookup user to local node");
+      this.logger.debug("lookup: looking up user on local node");
       const { err, user } = this.lookupUser(lookupKey);
-      if (DEBUGGING_LOCAL)
-        console.log(
-          "lookup: finished Server-side lookup, returning: ",
-          err,
-          user,
-        );
+      this.logger.debug({ err, user }, "lookup: finished server-side lookup");
       return { err, user };
     } else {
       try {
-        console.log("In lookup: lookup user to remote node");
+        this.logger.debug("lookup: looking up user on remote node");
         const successorClient = connect(successor);
         const user = await successorClient.lookupUserRemoteHelper({
           id: lookupKey,
@@ -409,8 +405,9 @@ export class UserService extends ChordNode {
         return { err: null, user };
       } catch (err) {
         handleGRPCErrors(
+          this.logger,
           "lookup",
-          "lookupUserRemotehelper",
+          "lookupUserRemoteHelper",
           successor.host,
           successor.port,
           err,
@@ -426,8 +423,9 @@ export class UserService extends ChordNode {
       return true;
     } catch (error) {
       handleGRPCErrors(
-        "migrateKeysAfterJoining",
-        "migrateUsersToNewPredecessor",
+        this.logger,
+        "migrateKeysBeforeDeparture",
+        "migrateUsersToSuccessor",
         this.predecessor.host,
         this.predecessor.port,
         error,
@@ -444,8 +442,9 @@ export class UserService extends ChordNode {
       await successorClient.migrateUsersToPredecessorRemoteHelper();
     } catch (error) {
       handleGRPCErrors(
+        this.logger,
         "migrateKeysAfterJoining",
-        "migrateUsersToNewPredecessor",
+        "migrateUsersToPredecessorRemoteHelper",
         this.predecessor.host,
         this.predecessor.port,
         error,
@@ -477,6 +476,7 @@ export class UserService extends ChordNode {
           this.removeUser(hashedKey);
         } catch (error) {
           handleGRPCErrors(
+            this.logger,
             "migrateUsersToPredecessor",
             "insertUserRemoteHelper",
             this.predecessor.host,
@@ -502,6 +502,7 @@ export class UserService extends ChordNode {
         this.removeUser(hashedKey);
       } catch (error) {
         handleGRPCErrors(
+          this.logger,
           "migrateUsersToSuccessor",
           "insertUserRemoteHelper",
           this.predecessor.host,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -3,6 +3,7 @@ import process from "process";
 import crypto from "crypto";
 import * as grpc from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
+import pino from "pino";
 
 const PROTO_PATH = path.resolve(import.meta.dirname, "../protos/chord.proto");
 
@@ -19,11 +20,16 @@ export const HASH_BIT_LENGTH = 32; //TBD
 export const FIBONACCI_ALPHA = 0.7;
 export const IS_FIBONACCI_CHORD: boolean = false;
 export const NULL_NODE = { id: null, host: null, port: null };
-export const DEBUGGING_LOCAL = false;
 export const SUCCESSOR_TABLE_MAX_LENGTH = Math.max(
   Math.ceil(HASH_BIT_LENGTH / 4),
   1,
 );
+
+export function createLogger(host: string, port: number) {
+  return pino({ level: process.env.LOG_LEVEL ?? "info" }).child({
+    node: `${host}:${port}`,
+  });
+}
 
 /**
  * Accounts for the modulo arithmetic to determine whether the input value is within the bounds.
@@ -92,9 +98,6 @@ export async function computeIntegerHash(
   stringForHashing: string,
   highOrderBits: boolean = true,
 ): Promise<number> {
-  // enable debugging output
-  const DEBUGGING_LOCAL = false;
-
   const MAX_JS_INT_BIT_LENGTH = 32;
   const BIT_PER_HEX_CHARACTER = 4;
   if (HASH_BIT_LENGTH > MAX_JS_INT_BIT_LENGTH) {
@@ -105,8 +108,6 @@ export async function computeIntegerHash(
     process.exit(-9);
   }
   let hashOutput = sha1(stringForHashing);
-  if (DEBUGGING_LOCAL)
-    console.log(`Full hash of "${stringForHashing}" is ${hashOutput}.`);
   // truncate because JavaScript only does bitwise operations on 32-bit numbers
   if (!highOrderBits) {
     // keep the low-order bits
@@ -120,12 +121,10 @@ export async function computeIntegerHash(
       MAX_JS_INT_BIT_LENGTH / BIT_PER_HEX_CHARACTER,
     );
   }
-  if (DEBUGGING_LOCAL) console.log(`Truncated string value is ${hashOutput}.`);
 
   let integerHash: number;
   // convert from hexadecimal to decimal
   integerHash = parseInt("0x" + hashOutput);
-  if (DEBUGGING_LOCAL) console.log(`Integer value is ${integerHash}.`);
 
   // truncate the hash to the desired number of bits
   if (!highOrderBits) {
@@ -135,8 +134,6 @@ export async function computeIntegerHash(
     // by picking the high-order bits
     integerHash = integerHash >>> (MAX_JS_INT_BIT_LENGTH - HASH_BIT_LENGTH);
   }
-  if (DEBUGGING_LOCAL)
-    console.log(`Truncated integer value is ${integerHash}.`);
 
   return integerHash;
 }
@@ -153,102 +150,119 @@ interface GRPCError {
 }
 
 export function handleGRPCErrors(
+  logger: pino.Logger,
   scope: string,
   call: string,
   host: string,
   port: number,
   err: GRPCError,
 ) {
+  const target = `${host}:${port}`;
   switch (err.code) {
     case 0:
-      console.log(
-        `${scope}: call to ${call} on ${host}:${port} returned OK. Should not have thrown`,
+      logger.warn(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} returned OK. Should not have thrown`,
       );
       break;
     case 1:
-      console.log(`${scope}: call to ${call} on ${host}:${port} was cancelled`);
+      logger.warn(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} was cancelled`,
+      );
       break;
     case 2:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} returned unknown error`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} returned unknown error`,
       );
       break;
     case 3:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} rejected due to invalid arguments`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} rejected due to invalid arguments`,
       );
       break;
     case 4:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} exceeded deadline`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} exceeded deadline`,
       );
       break;
     case 5:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} requested an entity that was not found`,
+      logger.warn(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} requested an entity that was not found`,
       );
       break;
     case 6:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} attempted to created an entity that already exists`,
+      logger.warn(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} attempted to create an entity that already exists`,
       );
       break;
     case 7:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} rejected because permission was denied`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} rejected because permission was denied`,
       );
       break;
     case 8:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} failed because a resource is exhausted`,
-        err,
+      logger.error(
+        { scope, call, target, err },
+        `${scope}: call to ${call} on ${target} failed because a resource is exhausted`,
       );
       break;
     case 9:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} failed due to pailed precondition `,
-        err,
+      logger.error(
+        { scope, call, target, err },
+        `${scope}: call to ${call} on ${target} failed due to failed precondition`,
       );
       break;
     case 10:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} was aborted `,
-        err,
+      logger.error(
+        { scope, call, target, err },
+        `${scope}: call to ${call} on ${target} was aborted`,
       );
       break;
     case 11:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} rejected because out of range`,
-        err,
+      logger.error(
+        { scope, call, target, err },
+        `${scope}: call to ${call} on ${target} rejected because out of range`,
       );
       break;
     case 12:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port}, which is unimplemented `,
-        err,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target}, which is unimplemented`,
       );
       break;
     case 13:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} caused Internal Error `,
+      logger.error(
+        { scope, call, target, err },
+        `${scope}: call to ${call} on ${target} caused Internal Error`,
       );
-      console.trace(err);
       break;
     case 14:
-      console.log(`${scope}: Unable to connect to ${host}:${port}`);
+      logger.warn(
+        { scope, call, target },
+        `${scope}: Unable to connect to ${target}`,
+      );
       break;
     case 15:
-      console.log(
-        `${scope}: call to ${call} on ${host}:${port} failed due to unrecoverable data loss or corruption`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} failed due to unrecoverable data loss or corruption`,
       );
       break;
     case 16:
-      console.error(
-        `${scope}: call to ${call} on ${host}:${port} rejected because authentication credentials were missing`,
+      logger.error(
+        { scope, call, target },
+        `${scope}: call to ${call} on ${target} rejected because authentication credentials were missing`,
       );
       break;
     default:
-      console.trace(`${scope}:`, err);
+      logger.error({ scope, err }, `${scope}: unexpected gRPC error`);
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,15 @@ services:
       dockerfile: NodeDockerfile
     ports:
       - "8440:1337"
+    environment:
+      - LOG_LEVEL=info
     command: "pnpm run devServer --host node_primary --knownHost node_primary --knownPort 1337"
   node_secondary:
     build:
       context: .
       dockerfile: NodeDockerfile
+    environment:
+      - LOG_LEVEL=info
     command: "pnpm run devServer --knownHost node_primary --knownPort 1337"
     depends_on:
       - node_primary

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@grpc/grpc-js": "^1.12.5",
     "@grpc/proto-loader": "^0.7.0",
     "express": "^4.21.0",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
     devDependencies:
       "@types/express":
         specifier: ^5.0.0
@@ -89,6 +92,12 @@ packages:
     resolution:
       {
         integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==,
+      }
+
+  "@pinojs/redact@0.4.0":
+    resolution:
+      {
+        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
       }
 
   "@pkgr/core@0.2.10":
@@ -262,6 +271,13 @@ packages:
       {
         integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
       }
+
+  atomic-sleep@1.0.0:
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: ">=8.0.0" }
 
   body-parser@1.20.5:
     resolution:
@@ -688,6 +704,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  on-exit-leak-free@2.1.2:
+    resolution:
+      {
+        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+      }
+    engines: { node: ">=14.0.0" }
+
   on-finished@2.4.1:
     resolution:
       {
@@ -721,6 +744,25 @@ packages:
       }
     engines: { node: ">=12" }
 
+  pino-abstract-transport@3.0.0:
+    resolution:
+      {
+        integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
+      }
+
+  pino-std-serializers@7.1.0:
+    resolution:
+      {
+        integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
+      }
+
+  pino@10.3.1:
+    resolution:
+      {
+        integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
+      }
+    hasBin: true
+
   prettier@3.8.3:
     resolution:
       {
@@ -738,6 +780,12 @@ packages:
     hasBin: true
     peerDependencies:
       prettier: ^3.0.0
+
+  process-warning@5.0.0:
+    resolution:
+      {
+        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+      }
 
   protobufjs@7.6.1:
     resolution:
@@ -760,6 +808,12 @@ packages:
       }
     engines: { node: ">=0.6" }
 
+  quick-format-unescaped@4.0.4:
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
+
   range-parser@1.2.1:
     resolution:
       {
@@ -774,6 +828,19 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  real-require@0.2.0:
+    resolution:
+      {
+        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+      }
+    engines: { node: ">= 12.13.0" }
+
+  real-require@1.0.0:
+    resolution:
+      {
+        integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==,
+      }
+
   require-directory@2.1.1:
     resolution:
       {
@@ -786,6 +853,13 @@ packages:
       {
         integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
       }
+
+  safe-stable-stringify@2.5.0:
+    resolution:
+      {
+        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+      }
+    engines: { node: ">=10" }
 
   safer-buffer@2.1.2:
     resolution:
@@ -848,6 +922,19 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  sonic-boom@4.2.1:
+    resolution:
+      {
+        integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==,
+      }
+
+  split2@4.2.0:
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: ">= 10.x" }
+
   statuses@2.0.2:
     resolution:
       {
@@ -868,6 +955,13 @@ packages:
         integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
       }
     engines: { node: ">=8" }
+
+  thread-stream@4.2.0:
+    resolution:
+      {
+        integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==,
+      }
+    engines: { node: ">=20" }
 
   tinyexec@0.3.2:
     resolution:
@@ -1037,6 +1131,8 @@ snapshots:
 
   "@js-sdsl/ordered-map@4.4.2": {}
 
+  "@pinojs/redact@0.4.0": {}
+
   "@pkgr/core@0.2.10": {}
 
   "@protobufjs/aspromise@1.1.2": {}
@@ -1122,6 +1218,8 @@ snapshots:
       color-convert: 2.0.1
 
   array-flatten@1.1.1: {}
+
+  atomic-sleep@1.0.0: {}
 
   body-parser@1.20.5:
     dependencies:
@@ -1356,6 +1454,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -1367,6 +1467,26 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      "@pinojs/redact": 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
 
   prettier@3.8.3: {}
 
@@ -1380,6 +1500,8 @@ snapshots:
       prettier: 3.8.3
       tinyexec: 0.3.2
       tslib: 2.8.1
+
+  process-warning@5.0.0: {}
 
   protobufjs@7.6.1:
     dependencies:
@@ -1405,6 +1527,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quick-format-unescaped@4.0.4: {}
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -1414,9 +1538,15 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
+
   require-directory@2.1.1: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -1479,6 +1609,12 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  split2@4.2.0: {}
+
   statuses@2.0.2: {}
 
   string-width@4.2.3:
@@ -1490,6 +1626,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   tinyexec@0.3.2: {}
 


### PR DESCRIPTION
## Summary

Closes #124

- Removes the hardcoded `DEBUGGING_LOCAL = false` boolean in `app/utils.ts` that required editing source and redeploying to toggle debug output
- Installs [pino](https://github.com/pinojs/pino) as a structured JSON logging library
- Each `ChordNode` / `UserService` instance creates a child logger bound with its `host:port` identity, making logs distinguishable across a multi-node Docker cluster
- All ~46 `if (DEBUGGING_LOCAL) console.log(...)` guards replaced with `this.logger.debug(...)`
- All `console.error(...)` calls replaced with `this.logger.error({ err }, ...)`
- `handleGRPCErrors` in `utils.ts` now accepts a `pino.Logger` as its first argument, enabling structured fields (`scope`, `call`, `target`) per gRPC error
- `docker-compose.yml` exposes `LOG_LEVEL` env var (default: `info`) on node services
- `CLAUDE.md` documents `LOG_LEVEL` values and `pino-pretty` for development

## Usage

```bash
# Default — only operations logged
npm run devServer -- --port 8440

# Verbose Chord protocol tracing
LOG_LEVEL=debug npm run devServer -- --port 8440

# Human-readable during development
LOG_LEVEL=debug npm run devServer -- --port 8440 | npx pino-pretty
```

## Test plan

- [ ] Start a cluster with `docker-compose up --scale node_secondary=5 -d` — verify `info`-level JSON lines appear (node start, insert/lookup events)
- [ ] Set `LOG_LEVEL=debug` on one node — verify finger table and stabilize traces appear
- [ ] Set `LOG_LEVEL=warn` — verify only warnings/errors appear
- [ ] `npm run client -- insert --port 8440 --id 2` then `lookup` — verify structured log lines include `node` field matching `host:port`
- [ ] `npm run client -- summary --port 8440` — verify finger table logged at `info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)