### PR TITLE
Fix race condition in user migration: await remote insert before local delete

### DIFF
--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -452,50 +452,50 @@ export class UserService extends ChordNode {
     }
   }
 
-  migrateUsersToPredecessor() {
+  async migrateUsersToPredecessor() {
     if (this.userMapIsEmpty()) return null;
 
     const client = connect(this.predecessor);
 
-    Object.keys(this.userMap)
-      .filter((hashedKey) =>
-        isInModuloRange(
-          parseInt(hashedKey, 10),
-          this.id,
-          false,
-          this.predecessor.id,
-          true,
-        ),
-      )
-      .forEach((hashedKey) => {
-        try {
-          client.insertUserRemoteHelper({
-            user: this.userMap[hashedKey],
-            edit: false,
-          });
-          this.removeUser(hashedKey);
-        } catch (error) {
-          handleGRPCErrors(
-            this.logger,
-            "migrateUsersToPredecessor",
-            "insertUserRemoteHelper",
-            this.predecessor.host,
-            this.predecessor.port,
-            error,
-          );
-        }
-      });
+    const keysToMigrate = Object.keys(this.userMap).filter((hashedKey) =>
+      isInModuloRange(
+        parseInt(hashedKey, 10),
+        this.id,
+        false,
+        this.predecessor.id,
+        true,
+      ),
+    );
+
+    for (const hashedKey of keysToMigrate) {
+      try {
+        await client.insertUserRemoteHelper({
+          user: this.userMap[hashedKey],
+          edit: false,
+        });
+        this.removeUser(hashedKey);
+      } catch (error) {
+        handleGRPCErrors(
+          this.logger,
+          "migrateUsersToPredecessor",
+          "insertUserRemoteHelper",
+          this.predecessor.host,
+          this.predecessor.port,
+          error,
+        );
+      }
+    }
     return null;
   }
 
-  migrateUsersToSuccessor() {
+  async migrateUsersToSuccessor() {
     if (this.userMapIsEmpty()) return null;
 
     const client = connect(this.fingerTable[0].successor);
 
-    Object.keys(this.userMap).forEach((hashedKey) => {
+    for (const hashedKey of Object.keys(this.userMap)) {
       try {
-        client.insertUserRemoteHelper({
+        await client.insertUserRemoteHelper({
           user: this.userMap[hashedKey],
           edit: false,
         });
@@ -510,15 +510,15 @@ export class UserService extends ChordNode {
           error,
         );
       }
-    });
+    }
     return null;
   }
 
-  migrateUsersToPredecessorRemoteHelper(
+  async migrateUsersToPredecessorRemoteHelper(
     _: any,
     callback: (call: any, arg1: {}) => void,
   ) {
-    callback(this.migrateUsersToPredecessor(), {});
+    callback(await this.migrateUsersToPredecessor(), {});
   }
 
   // Checks if the local this.userMap is an empty object


### PR DESCRIPTION
## Summary

- Fixes the race condition reported in #123 where `removeUser` ran before the async `insertUserRemoteHelper` call completed, risking permanent data loss during node migration
- Made `migrateUsersToPredecessor` and `migrateUsersToSuccessor` `async`, replacing `forEach` with `for...of` + `await` on each remote insert
- Made `migrateUsersToPredecessorRemoteHelper` `async` so the gRPC callback only fires after migration is fully complete (previously the caller received a success response before any inserts had landed)

## Test plan

- [ ] Start a multi-node cluster: `docker-compose up --scale node_secondary=5 -d`
- [ ] Bulk insert users: `npm run client -- bulkInsert --path ./data/tinyUsers.json`
- [ ] Verify all users are present: `npm run client -- summary --port 8440`
- [ ] Scale down the cluster to trigger departure migration: `docker-compose up --scale node_secondary=2 -d`
- [ ] Verify no users were lost after the scale-down by re-running `summary` against the remaining nodes
- [ ] Scale up to trigger join migration and verify users redistribute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)