### PR TITLE
Make ChordNode abstract with abstract migrateKeys methods

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -25,7 +25,7 @@ interface FingerTableEntry {
   successor: Node;
 }
 
-export class ChordNode {
+export abstract class ChordNode {
   id: number;
   host: string;
   port: number;
@@ -1328,14 +1328,6 @@ export class ChordNode {
     process.exit(0);
   }
 
-  /**
-   * Placeholder for data migration within the joinCluster() call.
-   */
-  async migrateKeysAfterJoining() {
-    throw new Error("Method migrateKeysAfterJoin has not been implemented");
-  }
-
-  async migrateKeysBeforeDeparture(): Promise<boolean> {
-    throw new Error("Method migrateKeysAfterJoin has not been implemented");
-  }
+  abstract migrateKeysAfterJoining(): Promise<void>;
+  abstract migrateKeysBeforeDeparture(): Promise<boolean>;
 }


### PR DESCRIPTION
## Summary

- Declares `ChordNode` as `abstract` so it cannot be instantiated directly
- Replaces the two runtime-throw stub methods (`migrateKeysAfterJoining`, `migrateKeysBeforeDeparture`) with `abstract` declarations, turning a potential runtime crash into a compile-time error for any future subclass that forgets to implement them
- Removes the misleading error message that incorrectly named `migrateKeysAfterJoin` in both stubs

`UserService` already overrides both methods, so no application behaviour changes.

Closes #122

## Test plan

- [ ] `npx tsc --noEmit` reports only the pre-existing `pino` module-not-found warning (no new errors)
- [ ] Docker cluster starts and stabilises normally (`docker-compose up --scale node_secondary=5 -d`)
- [ ] `npm run client -- bulkInsert` and `lookup` work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)