### PR TITLE
Implement PATCH semantics for user edits via FieldMask (closes #57)

### DIFF
--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -217,20 +217,35 @@ export class UserService extends ChordNode {
       : clonedUserEdit.user.metadata.secondaryHash;
 
     this.logger.debug({ clonedUserEdit }, "insertUser");
-    const { user, edit } = clonedUserEdit;
+    const { user, edit, update_mask } = clonedUserEdit;
+    const paths: string[] = update_mask?.paths ?? [];
 
     if (this.userMap[key] && !edit) {
       this.logger.warn(`insertUser: user already exists at hash ${key}`);
       return { code: 6 };
+    }
+
+    if (edit && paths.length > 0) {
+      // Partial update: merge only the fields named in the mask
+      if (!this.userMap[key]) {
+        this.logger.warn(
+          `insertUser: user not found at hash ${key} for partial edit`,
+        );
+        return { code: 5 };
+      }
+      for (const field of paths) {
+        (this.userMap[key] as any)[field] = user[field];
+      }
+      this.logger.info(
+        `insertUser: Partially edited User ${user.id} at hash ${key} (fields: ${paths.join(", ")})`,
+      );
     } else {
       this.userMap[key] = user;
-      if (edit) {
-        this.logger.info(`insertUser: Edited User ${user.id} at hash ${key}`);
-      } else {
-        this.logger.info(`insertUser: Inserted User ${user.id} at hash ${key}`);
-      }
-      return null;
+      this.logger.info(
+        `insertUser: ${edit ? "Edited" : "Inserted"} User ${user.id} at hash ${key}`,
+      );
     }
+    return null;
   }
 
   // gRPC Handler to allow other nodes to insert users into our local state

--- a/client/common.ts
+++ b/client/common.ts
@@ -96,7 +96,6 @@ export class Client {
     if (!rest.id) {
       console.log("id is a mandatory field!");
       console.log("node client insert --id=42424242");
-
       console.log(
         "optional fields include reputation, creationDate, displayName, lastAccessDate, websiteUrl, location, aboutMe, views, upVotes, downVotes, profileImageUrl, accountId",
       );
@@ -105,10 +104,46 @@ export class Client {
       );
       process.exit();
     }
+
+    if (rest.edit) {
+      const editableFields = [
+        "reputation",
+        "creationDate",
+        "displayName",
+        "lastAccessDate",
+        "websiteUrl",
+        "location",
+        "aboutMe",
+        "views",
+        "upVotes",
+        "downVotes",
+        "profileImageUrl",
+        "accountId",
+      ];
+      const paths = editableFields.filter((f) => rest[f] !== undefined);
+      if (paths.length === 0) {
+        console.log(
+          'edit requires at least one field to update (e.g. --displayName="Alice")',
+        );
+        process.exit();
+      }
+      const user: any = { id: rest.id };
+      for (const field of paths) {
+        user[field] = rest[field];
+      }
+      try {
+        await this.client.insert({ user, edit: true, update_mask: { paths } });
+        console.log("User edited successfully");
+      } catch (err) {
+        console.log("User edit error:", err);
+      }
+      return;
+    }
+
     const user = {
       id: rest.id,
       reputation: rest.reputation || 0,
-      creationDate: rest.creationDate || Date.now().toString(), // Not the right format, but whatever...
+      creationDate: rest.creationDate || Date.now().toString(),
       displayName: rest.displayName || "",
       lastAccessDate: rest.lastAccessDate || "",
       websiteUrl: rest.websiteUrl || "",
@@ -117,28 +152,19 @@ export class Client {
       views: rest.views || 0,
       upVotes: rest.upVotes || 0,
       downVotes: rest.downVotes || 0,
-      profileImageUrl: rest.profileImageUrl || 0,
-      accountId: rest.accoutId || 0,
+      profileImageUrl: rest.profileImageUrl || "",
+      accountId: rest.accountId || 0,
     };
     try {
-      const _ = await this.client.insert({ user, edit: rest.edit });
-      if (rest.edit) {
-        console.log("User edited successfully");
-      } else {
-        console.log("User inserted successfully");
-      }
+      await this.client.insert({ user, edit: false });
+      console.log("User inserted successfully");
     } catch (err) {
-      if (rest.edit) {
-        console.log(err);
-        console.log("User edit error:", err);
-      } else {
-        switch (err.code) {
-          case 6:
-            console.log("User already exists!");
-            break;
-          default:
-            console.log("User insertion error:", err);
-        }
+      switch (err.code) {
+        case 6:
+          console.log("User already exists!");
+          break;
+        default:
+          console.log("User insertion error:", err);
       }
     }
   }

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package chord;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
 
 service Node {
   // Chord Library Level RPC Calls
@@ -90,5 +91,6 @@ message User {
 
 message UserEdit {
   User user = 1;
-  bool edit = 2; 
+  bool edit = 2;
+  google.protobuf.FieldMask update_mask = 3;
 }


### PR DESCRIPTION
## Summary

- Adds `google.protobuf.FieldMask update_mask` field to the `UserEdit` proto message, letting callers declare exactly which fields they want to mutate
- Client (`edit` command) now sends only the explicitly-provided CLI flags as the user payload, populates `update_mask.paths`, and exits with a clear error when no fields are given
- Server `insertUser()` merges only the named fields into the existing stored user; all other fields are left unchanged; editing a non-existent user now returns `NOT_FOUND` (gRPC code 5)
- Full-replace edits (no mask) and all migration paths are unaffected — backward-compatible

## Test plan

```bash
# Start a node
node ./app/node.ts --port 8460

# Insert a user with several fields
npm run client -- insert --port 8460 --id 42 --displayName "Alice" --reputation 100 --location "NYC"
# → "User inserted successfully"

# Partial edit — change only displayName
npm run client -- edit --port 8460 --id 42 --displayName "Alice (edited)"
# → "User edited successfully"

# Confirm reputation (100) and location ("NYC") are unchanged
npm run client -- lookup --port 8460 --id 42
# → displayName: "Alice (edited)", reputation: 100, location: "NYC"

# Edit a non-existent user — should fail with NOT_FOUND
npm run client -- edit --port 8460 --id 9999 --displayName "Ghost"
# → "User edit error: Error: 5 NOT_FOUND ..."

# Edit with no fields — should print usage error
npm run client -- edit --port 8460 --id 42
# → 'edit requires at least one field to update (e.g. --displayName="Alice")'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)