### PR TITLE
Enable TypeScript strict mode (closes #179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Type-check
-        run: pnpm exec tsc --noEmit
+        run: pnpm typecheck
 
       - name: Format check
         run: pnpm exec prettier --check .

--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -11,17 +11,12 @@ import {
   IS_FIBONACCI_CHORD,
   SUCCESSOR_TABLE_MAX_LENGTH,
   NULL_NODE,
+  Node,
 } from "./utils.ts";
 const phi = (1 + Math.sqrt(5)) / 2;
 
-interface Node {
-  id: number;
-  host: string;
-  port: number;
-}
-
 interface FingerTableEntry {
-  start: number;
+  start: number | null;
   successor: Node;
 }
 
@@ -43,14 +38,22 @@ export abstract class ChordNode {
   fingerToFix: number = 0;
   checkPredecessorIsLocked: boolean = false;
 
-  constructor({ id, host, port }) {
+  constructor({
+    id,
+    host,
+    port,
+  }: {
+    id?: number;
+    host?: string;
+    port?: number;
+  }) {
     if (!host || !port) {
       console.error(
         "ChordNode constructor did not receive host or port as expected",
       );
       process.exit(-9);
     }
-    this.id = id;
+    this.id = id ?? 0;
     this.host = host;
     this.port = port;
     this.logger = createLogger(host, port);
@@ -409,7 +412,7 @@ export abstract class ChordNode {
   }) {
     this.fingerTable.forEach((fingerTableEntry) => {
       call.write({
-        index: fingerTableEntry.start,
+        index: fingerTableEntry.start!,
         node: fingerTableEntry.successor,
       });
     });
@@ -504,7 +507,7 @@ export abstract class ChordNode {
       try {
         possibleCollidingNode = await this.findSuccessor(this.id, knownNode);
       } catch (err) {
-        possibleCollidingNode = null;
+        possibleCollidingNode = NULL_NODE;
       }
       if (this.iAmTheNode(possibleCollidingNode)) {
         // node collision
@@ -576,7 +579,7 @@ export abstract class ChordNode {
    * Returns a node's ID, making an RPC if necessary.
    * @returns - node's ID, or null if error
    */
-  async getNodeId(knownNode: Node): Promise<number> {
+  async getNodeId(knownNode: Node): Promise<number | null> {
     let nodeId = null;
     let knownNodeObject = NULL_NODE;
     let selfNodeString = (this.host + ":" + this.port).toLowerCase();
@@ -626,7 +629,7 @@ export abstract class ChordNode {
     let nPrimeSuccessor = NULL_NODE;
     try {
       nPrimeSuccessor = await this.findSuccessor(
-        this.fingerTable[0].start,
+        this.fingerTable[0].start!,
         nPrime,
       );
     } catch (err) {
@@ -688,7 +691,7 @@ export abstract class ChordNode {
       } else {
         try {
           this.fingerTable[i + 1].successor = await this.findSuccessor(
-            this.fingerTable[i + 1].start,
+            this.fingerTable[i + 1].start!,
             nPrime,
           );
         } catch (err) {
@@ -1118,7 +1121,7 @@ export abstract class ChordNode {
       let nSuccessor = NULL_NODE;
       try {
         nSuccessor = await this.findSuccessor(
-          this.fingerTable[this.fingerToFix].start,
+          this.fingerTable[this.fingerToFix].start!,
           this.encapsulateSelf(),
         );
         if (nSuccessor.id !== null) {
@@ -1142,7 +1145,7 @@ export abstract class ChordNode {
   /**
    * Checks to make sure that the predecessor is still responsive
    */
-  async checkPredecessor() {
+  async checkPredecessor(): Promise<boolean> {
     if (!this.checkPredecessorIsLocked) {
       this.checkPredecessorIsLocked = true;
       if (this.predecessor.id !== null && !this.iAmMyOwnPredecessor()) {
@@ -1159,7 +1162,7 @@ export abstract class ChordNode {
             err,
           );
           // Wipe out the predecessor if it doesn't respond
-          this.predecessor = { id: null, host: null, port: null };
+          this.predecessor = NULL_NODE;
           this.checkPredecessorIsLocked = false;
           return false;
         }
@@ -1167,6 +1170,7 @@ export abstract class ChordNode {
       this.checkPredecessorIsLocked = false;
       return true;
     }
+    return false;
   }
 
   /**

--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -11,7 +11,7 @@ import {
   IS_FIBONACCI_CHORD,
   SUCCESSOR_TABLE_MAX_LENGTH,
   NULL_NODE,
-  Node,
+  type Node,
 } from "./utils.ts";
 const phi = (1 + Math.sqrt(5)) / 2;
 

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -51,7 +51,15 @@ interface User {
 export class UserService extends ChordNode {
   userMap: { [key: string]: User[] };
 
-  constructor({ id, host = os.hostname(), port = 1337 }) {
+  constructor({
+    id,
+    host = os.hostname(),
+    port = 1337,
+  }: {
+    id?: number;
+    host?: string;
+    port?: number;
+  }) {
     super({ id, host, port });
     this.userMap = {};
   }
@@ -152,7 +160,7 @@ export class UserService extends ChordNode {
   // gRPC Handler to allow other nodes to remove users from our local state
   async removeUserRemoteHelper(
     message: { request: { id: any; userId: number } },
-    callback: (call: { code: number }, arg1: {}) => void,
+    callback: (call: { code: number } | null, arg1: {}) => void,
   ) {
     this.logger.debug({ message }, "removeUserRemoteHelper");
     const err = this.removeUser(message.request.id, message.request.userId);
@@ -174,8 +182,8 @@ export class UserService extends ChordNode {
 
   async removeWithHash(userId: number, isPrimaryHash: boolean) {
     let successor = NULL_NODE;
-    let lookupKey: number = null;
-    let errorString: string = null;
+    let lookupKey: number | null = null;
+    let errorString: string | null = null;
     this.logger.info(`remove: Attempting to remove user ${userId}`);
 
     //compute primary user ID from hash
@@ -279,7 +287,7 @@ export class UserService extends ChordNode {
   // gRPC Handler to allow other nodes to insert users into our local state
   async insertUserRemoteHelper(
     message: { request: any },
-    callback: (call: { code: number }, arg1: {}) => void,
+    callback: (call: { code: number } | null, arg1: {}) => void,
   ) {
     this.logger.debug({ message }, "insertUserRemoteHelper");
     const err = this.insertUser(message.request);
@@ -382,7 +390,7 @@ export class UserService extends ChordNode {
   // gRPC handler that returns a user locally from this node (hash in id, user ID in userId)
   fetch(
     message: { request: { id: any; userId: number } },
-    callback: (call: { code: number }, arg1: User) => void,
+    callback: (call: { code: number } | null, arg1: User | null) => void,
   ) {
     const { id, userId } = message.request;
     this.logger.info(`fetch: Requested User ${userId} at hash ${id}`);
@@ -441,8 +449,8 @@ export class UserService extends ChordNode {
   }
 
   async lookupWithHash(userId: number, isPrimaryHash: boolean) {
-    let lookupKey: number = null;
-    let errorString: string = null;
+    let lookupKey: number | null = null;
+    let errorString: string | null = null;
     let successor = NULL_NODE;
 
     //compute primary user ID from hash

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -20,7 +20,14 @@ const chordProto = grpc.loadPackageDefinition(packageDefinition).chord as any;
 export const HASH_BIT_LENGTH = 32; //TBD
 export const FIBONACCI_ALPHA = 0.7;
 export const IS_FIBONACCI_CHORD: boolean = false;
-export const NULL_NODE = { id: null, host: null, port: null };
+
+export interface Node {
+  id: number | null;
+  host: string | null;
+  port: number | null;
+}
+
+export const NULL_NODE: Node = { id: null, host: null, port: null };
 export const SUCCESSOR_TABLE_MAX_LENGTH = Math.max(
   Math.ceil(HASH_BIT_LENGTH / 4),
   1,
@@ -45,12 +52,14 @@ export function createLogger(host: string, port: number) {
  * returns true if the input value is in - modulo - bounds; false otherwise
  */
 export function isInModuloRange(
-  inputValue: number,
-  lowerBound: number,
+  inputValue: number | null,
+  lowerBound: number | null,
   includeLower: boolean = true,
-  upperBound: number,
+  upperBound: number | null,
   includeUpper: boolean = false,
 ): boolean {
+  if (inputValue === null || lowerBound === null || upperBound === null)
+    return false;
   if (includeLower && includeUpper) {
     if (lowerBound > upperBound) {
       //looping through 0
@@ -154,12 +163,13 @@ export function handleGRPCErrors(
   logger: pino.Logger,
   scope: string,
   call: string,
-  host: string,
-  port: number,
-  err: GRPCError,
+  host: string | null,
+  port: number | null,
+  err: unknown,
 ) {
+  const grpcErr = err as GRPCError;
   const target = `${host}:${port}`;
-  switch (err.code) {
+  switch (grpcErr.code) {
     case 0:
       logger.warn(
         { scope, call, target },
@@ -210,25 +220,25 @@ export function handleGRPCErrors(
       break;
     case 8:
       logger.error(
-        { scope, call, target, err },
+        { scope, call, target, err: grpcErr },
         `${scope}: call to ${call} on ${target} failed because a resource is exhausted`,
       );
       break;
     case 9:
       logger.error(
-        { scope, call, target, err },
+        { scope, call, target, err: grpcErr },
         `${scope}: call to ${call} on ${target} failed due to failed precondition`,
       );
       break;
     case 10:
       logger.error(
-        { scope, call, target, err },
+        { scope, call, target, err: grpcErr },
         `${scope}: call to ${call} on ${target} was aborted`,
       );
       break;
     case 11:
       logger.error(
-        { scope, call, target, err },
+        { scope, call, target, err: grpcErr },
         `${scope}: call to ${call} on ${target} rejected because out of range`,
       );
       break;
@@ -240,7 +250,7 @@ export function handleGRPCErrors(
       break;
     case 13:
       logger.error(
-        { scope, call, target, err },
+        { scope, call, target, err: grpcErr },
         `${scope}: call to ${call} on ${target} caused Internal Error`,
       );
       break;
@@ -263,7 +273,7 @@ export function handleGRPCErrors(
       );
       break;
     default:
-      logger.error({ scope, err }, `${scope}: unexpected gRPC error`);
+      logger.error({ scope, err: grpcErr }, `${scope}: unexpected gRPC error`);
   }
 }
 
@@ -299,7 +309,15 @@ export function loadTlsCredentials(): {
  * Uses TLS when certs/ca.crt exists; falls back to insecure transport
  * (useful for environments where certs have not been generated yet).
  */
-export function connect({ host, port }: { host: string; port: number }) {
+export function connect({
+  host,
+  port,
+}: {
+  host: string | null;
+  port: number | null;
+}) {
+  if (!host || !port)
+    throw new Error(`Cannot connect: null node (host=${host}, port=${port})`);
   const tls = loadTlsCredentials();
   const credentials = tls
     ? grpc.credentials.createSsl(tls.ca)

--- a/client/common.ts
+++ b/client/common.ts
@@ -176,7 +176,8 @@ export class Client {
       await this.client.insert({ user, edit: false });
       console.log("User inserted successfully");
     } catch (err) {
-      switch (err.code) {
+      const grpcErr = err as { code?: number };
+      switch (grpcErr.code) {
         case 6:
           console.log("User already exists!");
           break;

--- a/data/cleanData.ts
+++ b/data/cleanData.ts
@@ -23,8 +23,8 @@ interface XMLGeneratedPerson {
 // Quick and dirty script to convert the StackOverflow data from XML to JSON
 fs.readFile(`${import.meta.dirname}/users.xml`, (_err, data) => {
   parseString(data, (_err, rawData) => {
-    const result = {};
-    const tinyResult = {};
+    const result: Record<string | number, unknown> = {};
+    const tinyResult: Record<string | number, unknown> = {};
     rawData.users.row
       .map((person: { [x: string]: any }) => person["$"])
       .map((person: XMLGeneratedPerson) => ({

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app/node.ts",
   "type": "module",
   "scripts": {
+    "typecheck": "tsc",
     "test": "node --test \"test/**/*.test.ts\"",
     "cleanData": "node ./data/cleanData.ts",
     "server": "node ./app/node.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "allowJs": false,
     "module": "nodenext",
     "moduleResolution": "nodenext",

--- a/web/web.ts
+++ b/web/web.ts
@@ -5,6 +5,18 @@ import path from "path";
 import { connect } from "../app/utils.ts";
 const PUBLIC_PATH = path.resolve(import.meta.dirname, "./public");
 
+interface NodeSnapshot {
+  host?: string;
+  port?: number;
+  id?: number;
+  fingerTable?: Record<number, unknown>;
+  userIds?: unknown[];
+  predecessor?: unknown;
+  successor?: { host?: string; port?: number };
+}
+
+type NetworkState = Record<string, NodeSnapshot>;
+
 const DEFAULT_HOST_NAME = os.hostname();
 const CRAWLER_INTERVAL_MS = 3000;
 
@@ -14,8 +26,8 @@ class ChordCrawler {
   #seedHost: string;
   #seedPort: number;
   #client: any;
-  #state: object = {};
-  #walk: Set<any> = new Set([]);
+  #state: NetworkState = {};
+  #walk: Set<string> = new Set([]);
   #canAdvance: boolean = true;
 
   get state() {
@@ -52,8 +64,8 @@ class ChordCrawler {
       let foundDangling = false;
       for (const storedConnectionString of Object.keys(this.#state)) {
         if (!this.#walk.has(storedConnectionString)) {
-          this.#host = this.#state[storedConnectionString].host;
-          this.#port = this.#state[storedConnectionString].port;
+          this.#host = this.#state[storedConnectionString].host!;
+          this.#port = this.#state[storedConnectionString].port!;
           foundDangling = true;
           break;
         }
@@ -89,8 +101,8 @@ class ChordCrawler {
     const randomNode =
       otherNodes[Math.floor(Math.random() * otherNodes.length)];
 
-    this.#host = randomNode.host;
-    this.#port = randomNode.port;
+    this.#host = randomNode.host!;
+    this.#port = randomNode.port!;
 
     // And we have to invalidate the current walk to avoid accidental pruning
     this.#walk.clear();
@@ -127,9 +139,12 @@ class ChordCrawler {
         const fingerTableStream = await this.#client.getFingerTableEntries();
         this.#state[connectionString].fingerTable = {};
         await new Promise<void>((resolve, reject) => {
-          fingerTableStream.on("data", ({ index, node }) => {
-            this.#state[connectionString].fingerTable[index] = node;
-          });
+          fingerTableStream.on(
+            "data",
+            ({ index, node }: { index: number; node: unknown }) => {
+              this.#state[connectionString].fingerTable![index] = node;
+            },
+          );
           fingerTableStream.on("end", resolve);
           fingerTableStream.on("error", reject);
         });
@@ -139,7 +154,7 @@ class ChordCrawler {
         this.#state[connectionString].userIds = [];
         await new Promise<void>((resolve, reject) => {
           userIdStream.on("data", (idWithMetadata: any) => {
-            this.#state[connectionString].userIds.push(idWithMetadata);
+            this.#state[connectionString].userIds!.push(idWithMetadata);
           });
           userIdStream.on("end", resolve);
           userIdStream.on("error", reject);
@@ -165,7 +180,7 @@ class ChordCrawler {
         // Advance to the successor or a known node in a partition
         this.#advance();
       } catch (err) {
-        if (err.code == 14) {
+        if ((err as { code?: number }).code == 14) {
           console.error(
             `Node ${connectionString} is unreachable — pruning and resetting to seed`,
           );


### PR DESCRIPTION
## Summary

Enables `\"strict\": true` in `tsconfig.json` and fixes all 106 resulting type errors across the codebase. The codebase now compiles cleanly under strict mode with zero errors.

### Key architectural changes

**`app/utils.ts`** — foundation changes that ripple everywhere:
- Export a new `Node` interface with nullable fields (`id: number | null`, `host: string | null`, `port: number | null`) to properly type the `NULL_NODE` sentinel used throughout the Chord protocol
- Type `NULL_NODE` explicitly as `Node`
- `isInModuloRange`: accept `number | null` for all numeric params, returning `false` when any is null (safe for NULL_NODE sentinels in ring comparisons)
- `handleGRPCErrors`: accept `unknown` for `err` and nullable `host`/`port` (gRPC errors in catch blocks are now properly typed)
- `connect`: accept nullable `host`/`port` with a runtime guard that throws a clear error if called with a null node (turns a silent crash into a clear message)

**`app/ChordNode.ts`**:
- Import `Node` from `utils.ts` instead of defining a local non-nullable version
- `FingerTableEntry.start`: `number | null` (initialized null, set in `joinCluster`)
- Constructor: explicit param type `{ id?: number; host?: string; port?: number }`, `this.id = id ?? 0` (overwritten by hash in `joinCluster` when not provided)
- `getNodeId`: return type `Promise<number | null>`
- `checkPredecessor`: explicit `Promise<boolean>` return type with `return false` when locked
- Replace bare `{ id: null, host: null, port: null }` literals with `NULL_NODE`
- Use `!` non-null assertions on `fingerTable[i].start` at the three `findSuccessor` call sites (start is always set before fixFingers/initFingerTable run)

**`app/UserService.ts`**:
- Constructor: explicit param type, no null for `id`
- `removeWithHash`/`lookupWithHash`: `let lookupKey: number | null` and `let errorString: string | null`
- gRPC callback types for `removeUserRemoteHelper`, `insertUserRemoteHelper`, and `fetch` now correctly accept `null` as the first arg (meaning no error)

**`client/common.ts`**, **`data/cleanData.ts`**, **`web/web.ts`**: smaller targeted fixes — cast `err` to `{ code?: number }` in catch blocks, type result maps as `Record<string | number, unknown>`, define `NetworkState` and `NodeSnapshot` types for the crawler's state, and type the fingerTable stream data callback.

## Test plan

- [x] `npx tsc` (with `strict: true`) exits 0 with zero type errors
- [x] Docker cluster starts and stabilizes (`docker-compose up --scale node_secondary=5 -d`)
- [x] Web UI shows ring topology at `localhost:1337/data`
- [x] CLI operations work: `npm run client -- insert --port 8440 --id 2` and `npm run client -- lookup --port 8440 --id 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)