### PR TITLE
Add pnpm test step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Type-check
         run: pnpm typecheck
 
+      - name: Test
+        run: pnpm test
+
       - name: Format check
         run: pnpm exec prettier --check .
 


### PR DESCRIPTION
## Summary

- Adds `pnpm test` step to `.github/workflows/ci.yml`, running `test/user-key-collision.test.ts` via Node's built-in test runner on every push and PR
- Step runs after type-check so type errors surface first

Closes #178

## Test plan

- [ ] CI run on this PR passes the new Test step
- [ ] A PR that breaks `test/user-key-collision.test.ts` is blocked by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)