### PR TITLE
Fix process.exit() with no code on join failure

### DIFF
--- a/app/node.ts
+++ b/app/node.ts
@@ -75,7 +75,7 @@ async function main() {
     await userServiceNode.joinCluster(knownNode);
   } catch (err) {
     console.error(err);
-    process.exit();
+    process.exit(1);
   }
 
   if (process.platform === "win32") {


### PR DESCRIPTION
## Summary

- Changes `process.exit()` → `process.exit(1)` in the `joinCluster` catch block in `app/node.ts`

`process.exit()` with no argument exits with code 0 (success). Process supervisors configured for `restart: on-failure` (Docker Compose, systemd, k8s) treat exit 0 as a clean shutdown and will not restart the node or fire alerts. Using `process.exit(1)` correctly signals an abnormal exit.

Closes #175

## Test plan

- [ ] Run `npm run devServer -- --port 8441 --knownPort 9999` (unreachable known port) and confirm the process exits with code 1: `echo $?` / `$LASTEXITCODE` should print `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)