### PR TITLE
Fix copy-paste error: removeWithHash logs "insert:" instead of "remove:"

### DIFF
--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -192,7 +192,7 @@ export class UserService extends ChordNode {
         ? await this.computeUserIdHashPrimary(userId)
         : await this.computeUserIdHashSecondary(userId);
     } else {
-      errorString = `insert: error computing hash of ${userId}.`;
+      errorString = `remove: error computing hash of ${userId}.`;
       this.logger.error(errorString);
       throw new RangeError(errorString);
     }


### PR DESCRIPTION
## Summary

- Fixes a copy-paste mistake in `app/UserService.ts`: the error message inside `removeWithHash` said `insert: error computing hash of ${userId}` instead of `remove:`, making a failed remove look like a failed insert in the logs.

Closes #170

## Test plan

- [ ] Grep confirms the string is gone: `grep -n "insert: error computing hash" app/UserService.ts` returns no matches
- [ ] The error path in `removeWithHash` now logs `remove: error computing hash of <id>.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)