### PR TITLE
Make computeIntegerHash and computeHostPortHash synchronous

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -455,7 +455,7 @@ export abstract class ChordNode {
 
     // Generate the ID for this node from the host connection strings if not already forced by user
     if (!this.id) {
-      this.id = await computeHostPortHash(this.host, this.port);
+      this.id = computeHostPortHash(this.host, this.port);
     }
 
     // initialize finger table with reasonable values

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -189,10 +189,10 @@ export class UserService extends ChordNode {
     //compute primary user ID from hash
     if (userId && userId !== null) {
       lookupKey = isPrimaryHash
-        ? await this.computeUserIdHashPrimary(userId)
-        : await this.computeUserIdHashSecondary(userId);
+        ? this.computeUserIdHashPrimary(userId)
+        : this.computeUserIdHashSecondary(userId);
     } else {
-      errorString = `insert: error computing hash of ${userId}.`;
+      errorString = `remove: error computing hash of ${userId}.`;
       this.logger.error(errorString);
       throw new RangeError(errorString);
     }
@@ -322,11 +322,12 @@ export class UserService extends ChordNode {
 
     // Add Metadata
     userEdit.user.metadata = {};
-    userEdit.user.metadata.primaryHash = await this.computeUserIdHashPrimary(
+    userEdit.user.metadata.primaryHash = this.computeUserIdHashPrimary(
       userEdit.user.id,
     );
-    userEdit.user.metadata.secondaryHash =
-      await this.computeUserIdHashSecondary(userEdit.user.id);
+    userEdit.user.metadata.secondaryHash = this.computeUserIdHashSecondary(
+      userEdit.user.id,
+    );
 
     // Execute Insert or Edit at primary and secondary hash
     const err1 = await this.insertWithHash(userEdit, true);
@@ -456,8 +457,8 @@ export class UserService extends ChordNode {
     //compute primary user ID from hash
     if (userId && userId !== null) {
       lookupKey = isPrimaryHash
-        ? await this.computeUserIdHashPrimary(userId)
-        : await this.computeUserIdHashSecondary(userId);
+        ? this.computeUserIdHashPrimary(userId)
+        : this.computeUserIdHashSecondary(userId);
     } else {
       errorString = `lookup: error computing hash of ${userId}.`;
       this.logger.error(errorString);
@@ -610,23 +611,17 @@ export class UserService extends ChordNode {
     );
   }
 
-  async computeUserIdHashPrimary(userId: number): Promise<number> {
+  computeUserIdHashPrimary(userId: number): number {
     const highOrderBits = true;
     let userIdString: string = userId.toString().toLowerCase();
-    let hashedUserId: number = await computeIntegerHash(
-      userIdString,
-      highOrderBits,
-    );
+    let hashedUserId: number = computeIntegerHash(userIdString, highOrderBits);
     return hashedUserId;
   }
 
-  async computeUserIdHashSecondary(userId: number): Promise<number> {
+  computeUserIdHashSecondary(userId: number): number {
     const highOrderBits = false;
     let userIdString: string = userId.toString().toLowerCase();
-    let hashedUserId: number = await computeIntegerHash(
-      userIdString,
-      highOrderBits,
-    );
+    let hashedUserId: number = computeIntegerHash(userIdString, highOrderBits);
     return hashedUserId;
   }
 }

--- a/app/node.ts
+++ b/app/node.ts
@@ -7,7 +7,7 @@ import { computeIntegerHash, HASH_BIT_LENGTH } from "./utils.ts";
 
 async function hashDryRun(sourceValue: string) {
   try {
-    const integerHash = await computeIntegerHash(sourceValue);
+    const integerHash = computeIntegerHash(sourceValue);
     console.log(`ID {${integerHash}} computed from hash of {${sourceValue}}`);
   } catch (err) {
     console.error(

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -104,10 +104,10 @@ export function sha1(source: string): string {
  * The function uses SHA-1 to compute an intermmediate string output,
  * then truncates to the user-specified size from the high-order bits.
  */
-export async function computeIntegerHash(
+export function computeIntegerHash(
   stringForHashing: string,
   highOrderBits: boolean = true,
-): Promise<number> {
+): number {
   const MAX_JS_INT_BIT_LENGTH = 32;
   const BIT_PER_HEX_CHARACTER = 4;
   if (HASH_BIT_LENGTH > MAX_JS_INT_BIT_LENGTH) {
@@ -148,10 +148,7 @@ export async function computeIntegerHash(
   return integerHash;
 }
 
-export async function computeHostPortHash(
-  host: string,
-  port: number,
-): Promise<number> {
+export function computeHostPortHash(host: string, port: number): number {
   return computeIntegerHash(`${host}:${port}`.toLowerCase());
 }
 


### PR DESCRIPTION
## Summary

`computeIntegerHash` and `computeHostPortHash` in `app/utils.ts` were declared `async` despite containing only synchronous operations (a `sha1()` call and arithmetic). Every call site paid a needless Promise allocation and microtask tick.

Changes:
- `app/utils.ts`: remove `async`/`Promise<number>` from `computeIntegerHash` and `computeHostPortHash`
- `app/UserService.ts`: remove `async`/`Promise<number>` from `computeUserIdHashPrimary` and `computeUserIdHashSecondary`; drop `await` from all four call sites
- `app/ChordNode.ts`: drop `await` from `computeHostPortHash` call
- `app/node.ts`: drop `await` from `computeIntegerHash` call

TypeScript type-check passes with no errors.

Closes #173

## Test plan

- [x] `pnpm typecheck` passes (no type errors)
- [x] `pnpm test` passes
- [x] Start a node with `npm run devServer -- --port 8440` and confirm it comes up without errors — the `computeHostPortHash` call in `joinCluster` is the first real exercise of the changed code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)