### PR TITLE
Fix web.ts missing --port default and remove dead argv guard

### DIFF
--- a/web/web.ts
+++ b/web/web.ts
@@ -197,22 +197,18 @@ class ChordCrawler {
 }
 
 function main() {
-  if (process.argv.length >= 2) {
-    const args = minimist(process.argv.slice(2));
-    const crawler = new ChordCrawler(
-      args.host || DEFAULT_HOST_NAME,
-      args.port,
-      args.interval || CRAWLER_INTERVAL_MS,
-    );
+  const args = minimist(process.argv.slice(2));
+  const crawler = new ChordCrawler(
+    args.host || DEFAULT_HOST_NAME,
+    args.port || 8440,
+    args.interval || CRAWLER_INTERVAL_MS,
+  );
 
-    const app = express();
-    const port = args.webPort || 1337;
-    app.use(express.static(PUBLIC_PATH));
-    app.get("/data", (_, res) => res.json(crawler.state));
-    app.listen(port, () =>
-      console.log(`Example app listening on port ${port}!`),
-    );
-  }
+  const app = express();
+  const port = args.webPort || 1337;
+  app.use(express.static(PUBLIC_PATH));
+  app.get("/data", (_, res) => res.json(crawler.state));
+  app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 }
 
 main();


### PR DESCRIPTION
## Summary

- Add `|| 8440` fallback for `args.port` so `ChordCrawler` doesn't receive `undefined` when `--port` is omitted (consistent with how `args.host` and `args.interval` already have defaults)
- Remove the always-true `process.argv.length >= 2` guard — `process.argv` always has at least 2 elements (node exe + script path), so the condition never filtered anything

Closes #186

## Test plan

- [ ] Start web server without `--port`: `npm run devWeb` — confirm it connects to port 8440 and the Express `/data` endpoint returns valid JSON
- [ ] Start web server with explicit `--port 8441` — confirm it connects to the specified port
- [ ] Verify the removed guard has no effect: the `main()` body always runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)