### PR TITLE
Split Client insert/edit into separate methods with precise types (closes #162)

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -1,5 +1,5 @@
 import minimist from "minimist";
-import { Client } from "./common.ts";
+import { Client, type InsertArgs, type EditArgs } from "./common.ts";
 
 const VALID_COMMANDS =
   "lookup, insert, edit, remove, bulkInsert, summary, fingerTable, predecessor, successor";
@@ -28,11 +28,13 @@ function main() {
     case "bulkInsert":
       client.bulkInsert({ path: args.path });
       break;
+    // minimist yields untyped args, so cast at this boundary; insert()/edit()
+    // validate id and (for edit) the at-least-one-field rule at runtime.
     case "insert":
-      client.insert({ ...args, edit: false });
+      client.insert(args as unknown as InsertArgs);
       break;
     case "edit":
-      client.insert({ ...args, edit: true });
+      client.edit(args as unknown as EditArgs);
       break;
     case "summary":
       client.summary();

--- a/client/common.ts
+++ b/client/common.ts
@@ -2,22 +2,33 @@ import path from "path";
 import fs from "fs";
 import { connect } from "../app/utils.ts";
 
-interface InsertArgs {
-  id?: number;
-  edit?: boolean;
-  reputation?: number;
-  creationDate?: string;
-  displayName?: string;
-  lastAccessDate?: string;
-  websiteUrl?: string;
-  location?: string;
-  aboutMe?: string;
-  views?: number;
-  upVotes?: number;
-  downVotes?: number;
-  profileImageUrl?: string;
-  accountId?: number;
+// Fields a caller may set on insert or change on edit. The server defaults any
+// omitted field on insert and leaves it untouched on a partial edit.
+interface EditableFields {
+  reputation: number;
+  creationDate: string;
+  displayName: string;
+  lastAccessDate: string;
+  websiteUrl: string;
+  location: string;
+  aboutMe: string;
+  views: number;
+  upVotes: number;
+  downVotes: number;
+  profileImageUrl: string;
+  accountId: number;
 }
+
+// Requires at least one key of T to be present (the rest stay optional).
+type AtLeastOne<T> = {
+  [K in keyof T]-?: Pick<T, K> & Partial<Omit<T, K>>;
+}[keyof T];
+
+// Insert needs an id; every user field is optional and defaulted server-side.
+export type InsertArgs = { id: number } & Partial<EditableFields>;
+
+// Edit needs an id plus at least one editable field to patch.
+export type EditArgs = { id: number } & AtLeastOne<EditableFields>;
 
 export class Client {
   host: string;
@@ -110,6 +121,8 @@ export class Client {
   }
 
   async insert(args: InsertArgs) {
+    // The CLI dispatches untyped minimist args, so guard `id` at runtime even
+    // though the type marks it required for programmatic callers.
     if (!args.id) {
       console.log("id is a mandatory field!");
       console.log("node client insert --id=42424242");
@@ -120,41 +133,6 @@ export class Client {
         'node client insert --id=42424242 --displayName="Sean McBride" --reputation=3 --website="https://www.bushido.codes"',
       );
       process.exit();
-    }
-
-    if (args.edit) {
-      const editableFields = [
-        "reputation",
-        "creationDate",
-        "displayName",
-        "lastAccessDate",
-        "websiteUrl",
-        "location",
-        "aboutMe",
-        "views",
-        "upVotes",
-        "downVotes",
-        "profileImageUrl",
-        "accountId",
-      ] as const;
-      const paths = editableFields.filter((f) => args[f] !== undefined);
-      if (paths.length === 0) {
-        console.log(
-          'edit requires at least one field to update (e.g. --displayName="Alice")',
-        );
-        process.exit();
-      }
-      const user: any = { id: args.id };
-      for (const field of paths) {
-        user[field] = args[field];
-      }
-      try {
-        await this.client.insert({ user, edit: true, update_mask: { paths } });
-        console.log("User edited successfully");
-      } catch (err) {
-        console.log("User edit error:", err);
-      }
-      return;
     }
 
     const user = {
@@ -184,6 +162,52 @@ export class Client {
         default:
           console.log("User insertion error:", err);
       }
+    }
+  }
+
+  async edit(args: EditArgs) {
+    // The CLI dispatches untyped minimist args, so re-check `id` and the
+    // at-least-one-field rule at runtime; `EditArgs` enforces them for typed
+    // callers. A no-field edit would otherwise overwrite the user with a
+    // bare { id }, wiping every other field server-side.
+    if (!args.id) {
+      console.log("id is a mandatory field!");
+      console.log(
+        'node client edit --id=42424242 --displayName="Sean McBride"',
+      );
+      process.exit();
+    }
+
+    const editableFields = [
+      "reputation",
+      "creationDate",
+      "displayName",
+      "lastAccessDate",
+      "websiteUrl",
+      "location",
+      "aboutMe",
+      "views",
+      "upVotes",
+      "downVotes",
+      "profileImageUrl",
+      "accountId",
+    ] as const;
+    const paths = editableFields.filter((f) => args[f] !== undefined);
+    if (paths.length === 0) {
+      console.log(
+        'edit requires at least one field to update (e.g. --displayName="Alice")',
+      );
+      process.exit();
+    }
+    const user: any = { id: args.id };
+    for (const field of paths) {
+      user[field] = args[field];
+    }
+    try {
+      await this.client.insert({ user, edit: true, update_mask: { paths } });
+      console.log("User edited successfully");
+    } catch (err) {
+      console.log("User edit error:", err);
     }
   }
 


### PR DESCRIPTION
## What & why

Closes #162.

`insert()` previously did double duty for both insert and edit, branching on a runtime `edit?: boolean` flag, so `InsertArgs` conflated two genuinely different shapes. This splits `Client` into two methods with precise signatures:

```ts
async insert(args: { id: number } & Partial<EditableFields>)
async edit(args:   { id: number } & AtLeastOne<EditableFields>)
```

- `EditableFields` is factored out as the shared field set.
- `AtLeastOne<T>` (the utility from the issue) makes a no-field `edit` a **compile-time error** for typed callers.
- `InsertArgs` is split into distinct `InsertArgs` / `EditArgs` types; the `edit?: boolean` flag is gone from both the interface and the method bodies.
- `client.ts` dispatch is now `client.insert(...)` / `client.edit(...)` — no more `edit: true/false` at call sites.

The gRPC wire still carries `edit` (the server's `insertUser` reads `{ user, edit, update_mask }`); only the **client-side** method API changed.

## One deliberate deviation from the issue

The issue frames `AtLeastOne` as *replacing* the runtime `process.exit()` guard. I kept the runtime guards (`id` present, and ≥1 editable field) **in addition to** the type, because the actual entry point — `client.ts` — feeds the methods **untyped** `minimist` args (`[arg: string]: any`), which bypass the type check at that boundary (hence the explicit cast there). Without the runtime field-guard, a CLI `edit --id=42` with no fields would send an empty `update_mask`, and the server's `insertUser` falls into its `else` branch and **overwrites the stored user with a bare `{ id }`, wiping every other field** (`app/UserService.ts` — the `edit && paths.length > 0` check is false, so it does `bucket[existingIndex] = user`). So the type guards typed callers; the runtime check guards the CLI. Happy to drop the runtime guard if you'd prefer to rely on the type alone.

## Verification

- `npm run typecheck` (strict `tsc`) — clean.
- Type constraints proven with a temporary `@ts-expect-error` attestation file (removed before commit): `edit({ id })` and `insert({ displayName })` both fail to compile; `edit({ id, displayName })` and `insert({ id })` compile. A clean build means every expected error fired.
- `npm test` — 2/2 pass.
- `prettier --write` applied; pre-commit hook clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
