### PR TITLE
Cancel stabilize/fixFingers/checkPredecessor timers in destructor() (closes #187)

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -37,6 +37,11 @@ export abstract class ChordNode {
   fixFingersIsLocked: boolean = false;
   fingerToFix: number = 0;
   checkPredecessorIsLocked: boolean = false;
+  // Periodic maintenance timers started in joinCluster(); cancelled in
+  // destructor() so they can't race the teardown sequence (see issue #187).
+  stabilizeTimer?: ReturnType<typeof setInterval>;
+  fixFingersTimer?: ReturnType<typeof setInterval>;
+  checkPredecessorTimer?: ReturnType<typeof setInterval>;
 
   constructor({
     id,
@@ -538,9 +543,12 @@ export abstract class ChordNode {
     // And now that we've joined a cluster, we need maintain our state
     // There might be some "critical section" type issues
     // we need to use a gate to protect in these functions
-    setInterval(this.stabilize.bind(this), 1000);
-    setInterval(this.fixFingers.bind(this), 3000);
-    setInterval(this.checkPredecessor.bind(this), 1000);
+    this.stabilizeTimer = setInterval(this.stabilize.bind(this), 1000);
+    this.fixFingersTimer = setInterval(this.fixFingers.bind(this), 3000);
+    this.checkPredecessorTimer = setInterval(
+      this.checkPredecessor.bind(this),
+      1000,
+    );
 
     this.logger.debug(
       {
@@ -1207,6 +1215,13 @@ export abstract class ChordNode {
    * Remove node from the chord gracefully by migrating keys to the remaining nodes.
    */
   async destructor() {
+    // Stop periodic maintenance before tearing down so stabilize/fixFingers/
+    // checkPredecessor can't race the migration: mutate successor/predecessor
+    // mid-flight or fire gRPC calls at departing nodes (issue #187).
+    clearInterval(this.stabilizeTimer);
+    clearInterval(this.fixFingersTimer);
+    clearInterval(this.checkPredecessorTimer);
+
     let migrationSeemsOK = false;
     let successor = NULL_NODE;
     let successorSeemsOK = false;

--- a/test/destructor-cancels-timers.test.ts
+++ b/test/destructor-cancels-timers.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { UserService } from "../app/UserService.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+// destructor() logs a couple of expected confirmExist failures for an empty
+// (single-node) cluster; silence the pino logger to keep test output clean.
+const noopLogger = new Proxy({}, { get: () => () => {} });
+
+// Regression test for #187: the stabilize/fixFingers/checkPredecessor timers
+// started in joinCluster() must be cancelled by destructor() so they cannot
+// race the teardown sequence.
+test("destructor() cancels the periodic maintenance timers", async () => {
+  const node = new UserService({ id: 1, host: "localhost", port: 9999 });
+  (node as any).logger = noopLogger;
+
+  // destructor() ends with process.exit(0); neutralize it so the assertions
+  // after the call still run (restored in finally).
+  const realExit = process.exit;
+  (process as any).exit = () => {};
+
+  let stabilizeCalls = 0;
+  let fixFingersCalls = 0;
+  let checkPredecessorCalls = 0;
+
+  // Swap the maintenance methods for fast, network-free counters so the timers
+  // exercise the same wiring joinCluster() sets up, minus the gRPC traffic.
+  (node as any).stabilize = async () => {
+    stabilizeCalls++;
+  };
+  (node as any).fixFingers = async () => {
+    fixFingersCalls++;
+  };
+  (node as any).checkPredecessor = async () => {
+    checkPredecessorCalls++;
+    return true;
+  };
+
+  // Mirror joinCluster(): store the interval handles on the very fields
+  // destructor() is expected to clear (short period to keep the test fast).
+  node.stabilizeTimer = setInterval(() => node.stabilize(), 5);
+  node.fixFingersTimer = setInterval(() => node.fixFingers(), 5);
+  node.checkPredecessorTimer = setInterval(() => node.checkPredecessor(), 5);
+
+  try {
+    await sleep(40);
+    assert.ok(stabilizeCalls > 0, "timers should be firing before shutdown");
+
+    await node.destructor();
+
+    const afterShutdown = {
+      stabilizeCalls,
+      fixFingersCalls,
+      checkPredecessorCalls,
+    };
+
+    // Wait well beyond the interval; with the timers cancelled the counts freeze.
+    await sleep(40);
+    assert.deepEqual(
+      { stabilizeCalls, fixFingersCalls, checkPredecessorCalls },
+      afterShutdown,
+      "no maintenance callback should fire after destructor()",
+    );
+  } finally {
+    // Clear timers (no-op once destructor cancelled them) and restore exit.
+    clearInterval(node.stabilizeTimer);
+    clearInterval(node.fixFingersTimer);
+    clearInterval(node.checkPredecessorTimer);
+    process.exit = realExit;
+  }
+});


### PR DESCRIPTION
## What & why

Closes #187.

`joinCluster()` started three periodic timers but threw the interval handles away:

```ts
setInterval(this.stabilize.bind(this), 1000);
setInterval(this.fixFingers.bind(this), 3000);
setInterval(this.checkPredecessor.bind(this), 1000);
```

So they kept firing all through `destructor()`'s teardown, racing the migration — `stabilize` could repoint `fingerTable[0].successor` mid-migration, `checkPredecessor` could null `this.predecessor` before `destructor()` notifies it, and `fixFingers` fired gRPC calls at departing nodes.

This stores the handles as instance fields and `clearInterval()`s them at the very top of `destructor()`, before any teardown work. (Matches the fix suggested in the issue; field type is `ReturnType<typeof setInterval>` and they're declared optional so the existing `strictPropertyInitialization` stays happy.)

## Regression test

Added `test/destructor-cancels-timers.test.ts`. It counts `stabilize`/`fixFingers`/`checkPredecessor` invocations, runs `destructor()`, and asserts none fire afterward. Two wrinkles worth flagging:
- `destructor()` ends in `process.exit(0)`, so the test stubs `process.exit` (restored in `finally`) — otherwise the post-call assertions never run and the test passes vacuously.
- The maintenance methods are swapped for network-free counters so the timers exercise the same wiring minus gRPC.

I confirmed the test genuinely catches the bug: **red** without the fix (`AssertionError: no maintenance callback should fire after destructor()`), **green** with it.

## Verification

- `npm run typecheck` (strict `tsc`) — clean.
- `npm test` — 3/3 pass (new test + existing two).
- `prettier --check` — clean.
- **Live swarm** (`docker compose up --scale node_secondary=3`): brought up a 4-node ring on this branch; `insert --id 7` + `lookup --id 7` route correctly through the ring, confirming the `joinCluster()` change doesn't disturb periodic maintenance.

### Note on graceful-shutdown testing in Docker
I verified cancellation via the deterministic unit test rather than by signalling a container, because the compose `command:` is a string → Docker runs it as `sh -c "pnpm run devServer …"` → `node --watch` → `node`. That chain doesn't forward `SIGTERM`, so `docker compose stop` never reaches `destructor()` at all. That's a pre-existing harness limitation (related to #176), independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
