### PR TITLE
Propagate remote gRPC errors in insertWithHash/removeWithHash (closes #181)

### DIFF
--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -212,12 +212,10 @@ export class UserService extends ChordNode {
       try {
         this.logger.debug("remove: removing user from remote node");
         const successorClient = connect(successor);
-        await successorClient.removeUserRemoteHelper(
-          { id: lookupKey, userId },
-          (err: any, _: any) => {
-            return err;
-          },
-        );
+        // Promise form: promisifyClient rejects with the remote gRPC error so a
+        // remote remove failure surfaces to the caller instead of being
+        // swallowed by an inline callback. See #181.
+        await successorClient.removeUserRemoteHelper({ id: lookupKey, userId });
       } catch (err) {
         handleGRPCErrors(
           this.logger,
@@ -367,13 +365,10 @@ export class UserService extends ChordNode {
           "insert: inserting user to remote node",
         );
         const successorClient = connect(successor);
-        await successorClient.insertUserRemoteHelper(
-          userEdit,
-          (err: any, _: any) => {
-            this.logger.debug("insert finishing");
-            return err;
-          },
-        );
+        // Promise form: promisifyClient rejects with the remote gRPC error
+        // (e.g. code 6 ALREADY_EXISTS) so duplicate inserts surface to the
+        // caller instead of being swallowed by an inline callback. See #181.
+        await successorClient.insertUserRemoteHelper(userEdit);
       } catch (err) {
         handleGRPCErrors(
           this.logger,


### PR DESCRIPTION
## What & why

Closes #181.

When a user's hash landed on a **remote** successor, `insertWithHash` and `removeWithHash` called the remote helper in callback style:

```ts
await successorClient.insertUserRemoteHelper(userEdit, (err, _) => { return err; });
```

`promisifyClient` falls through to raw callback mode whenever a function is passed as the second arg (`utils.ts:356`), so the `await`ed value was the gRPC call object — not a Promise — and the callback's `return err` was discarded (callbacks don't propagate returns). The method therefore returned `undefined` on the remote path, `insert()`/`remove()` saw `err1`/`err2` as falsy, and reported success even when the remote node returned `{ code: 6 }` / `{ code: 5 }`.

Fix: drop the inline callbacks and use the Promise form `promisifyClient` already provides — it rejects on the remote gRPC error, which the existing `catch` already logs and returns. No other changes needed.

## Verification — live 6-node ring (`docker compose up --scale node_secondary=5`)

Reproduced the issue's exact steps. Confirmed via server logs that **both** of user 2's hashes route remotely (to `node_secondary-5` and `node_secondary-3`, not `node_primary`), so this exercises the remote path the bug lives on:

**Insert**
- `insert --id 2` → `User inserted successfully`
- `insert --id 2` again → `User already exists!` ✅ (was the bug; master returns "successfully")

**Remove** (symmetric fix)
- `remove --id 2` → `User deleted`
- `lookup --id 2` → `not found` (gone from both replicas)
- `remove --id 2` again → `User not deleted` / `5 NOT_FOUND` ✅ (remote failure now surfaces; master swallowed it)

- `npm run typecheck` clean · `npm test` 3/3 · `prettier --check` clean.

### Why no unit test
The bug is purely a remote-routing behavior — a locally-routed insert already returns `code 6` correctly, so it only manifests across nodes. An automated regression test would need either a real two-node gRPC ring or dependency-injection around the module-level `connect()` (neither exists in the repo today), so I verified via the issue's documented multi-node repro instead. Happy to add a DI seam + test if you'd like that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
