### PR TITLE
Proto: use google.protobuf.Empty for ignored request/response types (closes #177)

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -264,8 +264,7 @@ export abstract class ChordNode {
       // use remote value
       const nodeQueriedClient = connect(nodeQueried);
       try {
-        nSuccessor =
-          await nodeQueriedClient.getSuccessorRemoteHelper(nodeQueried);
+        nSuccessor = await nodeQueriedClient.getSuccessorRemoteHelper();
       } catch (err) {
         nSuccessor = { id: null, host: null, port: null };
         handleGRPCErrors(
@@ -653,9 +652,7 @@ export abstract class ChordNode {
 
     let successorClient = connect(this.fingerTable[0].successor);
     try {
-      this.predecessor = await successorClient.getPredecessor(
-        this.fingerTable[0].successor,
-      );
+      this.predecessor = await successorClient.getPredecessor();
     } catch (err) {
       this.predecessor = NULL_NODE;
       handleGRPCErrors(
@@ -978,7 +975,7 @@ export abstract class ChordNode {
     if (!this.stabilizeIsLocked) {
       this.stabilizeIsLocked = true;
       let successorClient: {
-          getPredecessor: (arg0: Node) => any;
+          getPredecessor: () => any;
           notify: (arg0: Node) => any;
         },
         x: Node;
@@ -999,9 +996,7 @@ export abstract class ChordNode {
           return false;
         }
         try {
-          x = await successorClient.getPredecessor(
-            this.fingerTable[0].successor,
-          );
+          x = await successorClient.getPredecessor();
         } catch (err) {
           x = this.encapsulateSelf();
           handleGRPCErrors(
@@ -1159,7 +1154,7 @@ export abstract class ChordNode {
       if (this.predecessor.id !== null && !this.iAmMyOwnPredecessor()) {
         const predecessorClient = connect(this.predecessor);
         try {
-          const _ = await predecessorClient.getPredecessor(this.id);
+          const _ = await predecessorClient.getPredecessor();
         } catch (err) {
           handleGRPCErrors(
             this.logger,

--- a/client/common.ts
+++ b/client/common.ts
@@ -43,7 +43,7 @@ export class Client {
   async summary() {
     console.log("Client requesting summary:");
     try {
-      const node = await this.client.summary({ id: 1 });
+      const node = await this.client.summary();
       console.log(
         `The node returned id: ${node.id}, host: ${node.host}, port: ${node.port}`,
       );
@@ -54,7 +54,7 @@ export class Client {
 
   async fingerTable() {
     try {
-      const summary = await this.client.summary({ id: 1 });
+      const summary = await this.client.summary();
       console.log(
         `Finger table for node ${summary.id} (${summary.host}:${summary.port}):`,
       );

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -9,17 +9,17 @@ service Node {
   // Chord Library Level RPC Calls
   rpc getNodeIdRemoteHelper (NodeAddress) returns (NodeAddress) {}
   rpc findSuccessorRemoteHelper (RemoteId) returns (NodeAddress) {}
-  rpc getSuccessorRemoteHelper (NodeAddress) returns (NodeAddress) {}
+  rpc getSuccessorRemoteHelper (google.protobuf.Empty) returns (NodeAddress) {}
   rpc setSuccessor (NodeAddress) returns (google.protobuf.Empty) {}
-  rpc getPredecessor (NodeAddress) returns (NodeAddress) {}
+  rpc getPredecessor (google.protobuf.Empty) returns (NodeAddress) {}
   rpc setPredecessor (NodeAddress) returns (google.protobuf.Empty) {}
   rpc getFingerTableEntries (NodeAddress) returns (stream FingerTableEntry) {}
   rpc closestPrecedingFingerRemoteHelper (RemoteId) returns (NodeAddress) {}
   rpc notify (NodeAddress) returns (google.protobuf.Empty) {}
-  rpc updateFingerTable (FingerTableEntry) returns (NodeAddress) {}
+  rpc updateFingerTable (FingerTableEntry) returns (google.protobuf.Empty) {}
 
   // Application Level RPC Calls
-  rpc summary(Trash) returns (NodeAddress) {}
+  rpc summary(google.protobuf.Empty) returns (NodeAddress) {}
   rpc fetch (UserId) returns (User) {}
   rpc insert (UserEdit) returns (google.protobuf.Empty) {}
   rpc insertUserRemoteHelper (UserEdit) returns (google.protobuf.Empty) {}
@@ -47,10 +47,6 @@ message FingerTableEntry {
   NodeAddress node = 1;
   uint32 index = 2;
  }
-
-message Trash{
-  uint32 id = 1;
-}
 
 message UserId {
   uint32 id = 1;


### PR DESCRIPTION
## What & why

Closes #177. Four RPCs in `protos/chord.proto` declared non-empty payloads their implementations ignore. Replacing them with `google.protobuf.Empty` documents the real contract and drops needless serialization. The proto already imports/uses `google.protobuf.Empty` elsewhere, so no new infra.

| RPC | Change | Evidence it's ignored |
|---|---|---|
| `summary` | `Trash` → `Empty` (request) | handler is `summary(_: any, cb)`; `Trash` message removed (was unused elsewhere) |
| `getSuccessorRemoteHelper` | `NodeAddress` → `Empty` (request) | handler returns `this.fingerTable[0].successor`, never reads the request |
| `getPredecessor` | `NodeAddress` → `Empty` (request) | handler returns `this.predecessor`, never reads the request |
| `updateFingerTable` | returns `NodeAddress` → `Empty` | both handler paths `callback(null, {})`; all callers discard the return |

I also dropped the now-meaningless arguments at the call sites (`summary({id:1})`, `getPredecessor(node)`, `getPredecessor(this.id)`, `getSuccessorRemoteHelper(node)`) and tightened the `getPredecessor` annotation in `stabilize()` to `() => any`. Behavior is unchanged — these inputs were already ignored server-side, and an extra payload to an `Empty` request just serializes to nothing.

## Verification

- `npm run typecheck` clean · `npm test` 3/3 (importing `UserService` loads the proto, so a malformed proto would fail the run) · `prettier --write` on the TS files.
- **Live 4-node ring** (`docker compose up --scale node_secondary=3`) — exercised every changed RPC over the wire:
  - `summary` → returned node id/host/port
  - `predecessor` (`getPredecessor`, Empty req) → returned a **remote** predecessor
  - `successor` (`getSuccessorRemoteHelper`, Empty req) → returned a **remote** successor
  - `fingerTable` → ring formed, `finger[0]` points at a remote successor
  - The ring forming at all proves `getPredecessor` + `updateFingerTable` work remotely with `Empty` (they fire continuously during stabilization).
  - `insert`/`lookup` still work; swept the whole swarm's logs for deserialize/serialize/proto errors — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
