### PR TITLE
Bound graceful shutdown with a timeout so destructor() can't hang (closes #176)

### DIFF
--- a/app/node.ts
+++ b/app/node.ts
@@ -3,7 +3,7 @@ import minimist from "minimist";
 import { UserService } from "./UserService.ts";
 import readline from "readline";
 
-import { computeIntegerHash, HASH_BIT_LENGTH } from "./utils.ts";
+import { computeIntegerHash, HASH_BIT_LENGTH, withTimeout } from "./utils.ts";
 
 async function hashDryRun(sourceValue: string) {
   try {
@@ -94,20 +94,29 @@ async function main() {
     process.on("SIGTERM", () => process.kill(process.pid, "SIGINT"));
   }
 
-  // handle "ctrl + c" as a graceful exit
-  process.on("SIGINT", async function () {
-    console.log("\n\nUser issued ctrl+c");
-    await userServiceNode.destructor();
+  // Migrate keys on shutdown, but never hang forever: destructor() makes
+  // deadline-less gRPC calls to peers, so if a successor/predecessor is
+  // unreachable it would block past docker's 10s SIGKILL window. Bound it with
+  // a timeout and force-exit regardless of outcome (issue #176).
+  const SHUTDOWN_TIMEOUT_MS = 5000;
+  const gracefulShutdown = async (signal: string) => {
+    console.log(`\n\n${signal} caught`);
+    try {
+      await withTimeout(
+        userServiceNode.destructor(),
+        SHUTDOWN_TIMEOUT_MS,
+        "Graceful shutdown timed out",
+      );
+    } catch (err) {
+      console.error("Shutdown error:", err);
+    }
     console.log(`Exiting process ${process.pid}`);
-    process.exit();
-  });
+    process.exit(0);
+  };
 
-  process.on("SIGTERM", async function () {
-    console.log("\n\nSIGTERM caught");
-    await userServiceNode.destructor();
-    console.log(`Exiting process ${process.pid}`);
-    process.exit();
-  });
+  // handle "ctrl + c" as a graceful exit
+  process.on("SIGINT", () => gracefulShutdown("User issued ctrl+c (SIGINT)"));
+  process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 }
 
 main();

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -274,6 +274,25 @@ export function handleGRPCErrors(
   }
 }
 
+/**
+ * Races a promise against a timeout. Rejects with `new Error(message)` if the
+ * promise has not settled within `ms`; otherwise resolves/rejects with the
+ * promise's own outcome. Used to bound graceful shutdown so an unreachable
+ * peer can't block process exit forever (see #176). The timer is always
+ * cleared so it never keeps the event loop alive after the race settles.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // Canonical name used in ssl_target_name_override — must match a SAN in certs/server.crt.
 const TLS_TARGET_NAME = "chord-node";
 

--- a/test/with-timeout.test.ts
+++ b/test/with-timeout.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { withTimeout } from "../app/utils.ts";
+
+// Regression tests for #176: graceful shutdown must not hang forever when a
+// peer is unreachable. withTimeout() bounds destructor()'s deadline-less gRPC
+// calls; these cover its three outcomes.
+
+test("withTimeout resolves with the value when the promise settles in time", async () => {
+  const result = await withTimeout(Promise.resolve("ok"), 1000, "timed out");
+  assert.equal(result, "ok");
+});
+
+test("withTimeout rejects with the timeout error when the promise hangs", async () => {
+  // A promise that never settles — the timeout must fire instead of hanging.
+  await assert.rejects(
+    withTimeout(new Promise<never>(() => {}), 20, "shutdown timed out"),
+    /shutdown timed out/,
+  );
+});
+
+test("withTimeout propagates the promise's own rejection", async () => {
+  await assert.rejects(
+    withTimeout(Promise.reject(new Error("boom")), 1000, "timed out"),
+    /boom/,
+  );
+});


### PR DESCRIPTION
## What & why

Closes #176. The `SIGINT`/`SIGTERM` handlers in `app/node.ts` awaited `destructor()` unconditionally. `destructor()` makes sequential, **deadline-less** gRPC calls to peers (`confirmExist`, `migrateKeysBeforeDeparture`, `setSuccessor`, `setPredecessor`); if a successor/predecessor is unreachable, those can block forever and the process never exits — past docker's 10s SIGKILL window.

Fix:
- Add a small `withTimeout(promise, ms, message)` helper in `utils.ts` (races against a timeout; always clears the timer).
- Route both handlers through a shared `gracefulShutdown()` that wraps `destructor()` in a 5s timeout, logs any error, and force-exits regardless.

Bonus: previously a `destructor()` *rejection* would skip `process.exit()` entirely (unhandled rejection → hang); the `try/catch` fixes that too.

The Windows signal-emulation block and the two-handler structure are left intact — this only changes how `destructor()` is invoked.

## Verification

**Unit tests** (`test/with-timeout.test.ts`) — the deterministic proof of the mechanism, all green:
- resolves with the value when the promise settles in time,
- **rejects with the timeout error when the promise never settles** (completes in ~timeout, doesn't hang),
- propagates the inner promise's own rejection.

`npm run typecheck` clean · `npm test` 6/6 · `prettier` clean.

**Live docker** (and a correction to my own #187 PR):
- `docker compose stop`/`docker stop` **does** reach the handler — `SIGTERM caught` is logged. (My #187 PR speculated the `sh → pnpm → node --watch` chain swallowed SIGTERM; that was wrong. The #187 fix and its unit test are still correct, but that justification was off.)
- Healthy node shutdown: ~2.7s. With a frozen peer (`docker pause`) — single neighbor and both-neighbors-frozen: ~4.2s. Either way bounded, well under the 10s SIGKILL.
- I could **not** make `docker pause` reproduce a literal >5s hang in this environment: gRPC-js fails the frozen-peer calls at ~4s, so `destructor()` self-completes before the 5s net engages. The infinite-hang case the issue describes (true black-hole / cascade timing) is exactly what the unit test covers deterministically, so the timeout path is proven there rather than in docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
