### PR TITLE
Fix destructor() predecessor-notification error log to report the predecessor (closes #169)

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -1301,8 +1301,8 @@ export abstract class ChordNode {
           this.logger,
           "destructor",
           "setSuccessor",
-          this.fingerTable[0].successor.host,
-          this.fingerTable[0].successor.port,
+          this.predecessor.host,
+          this.predecessor.port,
           err,
         );
       }


### PR DESCRIPTION
## What & why

Closes #169. In `destructor()`'s notify-predecessor block, the code connects to `this.predecessor` and calls `setSuccessor` on it, but the failure handler passed the **successor's** host/port to `handleGRPCErrors`:

```ts
const predecessorClient = connect(this.predecessor);
await predecessorClient.setSuccessor(successor);
} catch (err) {
  handleGRPCErrors(this.logger, "destructor", "setSuccessor",
-   this.fingerTable[0].successor.host,   // wrong target
-   this.fingerTable[0].successor.port,
+   this.predecessor.host,
+   this.predecessor.port,
    err);
}
```

So a failed departure notification logged "Unable to connect to <successor>" for a call that actually targeted the predecessor — misleading when diagnosing departures. Now it logs the predecessor's address.

I checked the adjacent notify-successor block: it connects to `successor`, calls `setPredecessor`, and correctly logs `successor.host/.port` — so the bug is isolated to this one handler.

## Verification

- `npm run typecheck` clean · `npm test` 6/6 · prettier clean.
- This is an error-path **log-target** correction — the only observable effect is the host/port string in a log line that appears when the predecessor notification fails during departure. It's provably correct by inspection (connect target vs. logged target), so I verified by code inspection + the build rather than staging a contrived multi-node departure-failure just to read one log line. Happy to add a runtime repro if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
