### PR TITLE
bulkInsert: await inserts and read the file with fs.promises (closes #166)

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -219,11 +219,16 @@ export class Client {
     try {
       const jsonPath = path.resolve(import.meta.dirname, "..", args.path);
       console.log(jsonPath);
-      fs.readFile(jsonPath, "utf8", (err, rawData) => {
-        const data = JSON.parse(rawData);
-        const users: InsertArgs[] = Object.values(data);
-        users.forEach((user) => this.insert(user));
-      });
+      const rawData = await fs.promises.readFile(jsonPath, "utf8");
+      const data = JSON.parse(rawData);
+      const users: InsertArgs[] = Object.values(data);
+      // Await each insert sequentially so every user lands before the client
+      // exits — the old forEach fired the async inserts and returned, tearing
+      // down the process first. Sequential (vs Promise.all) also avoids firing
+      // tens of thousands of concurrent inserts at the cluster for users.json.
+      for (const user of users) {
+        await this.insert(user);
+      }
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## What & why

Closes #166. `bulkInsert` did:

```ts
fs.readFile(jsonPath, "utf8", (err, rawData) => {
  const data = JSON.parse(rawData);
  const users: InsertArgs[] = Object.values(data);
  users.forEach((user) => this.insert(user));   // fire-and-forget async
});
```

Two problems:
1. `forEach` fired the async gRPC inserts without `await`; the loop returned, the method exited, and the client process tore down before most inserts completed — so only the first few users (if any) landed.
2. The callback-based `fs.readFile` meant a read/`JSON.parse` error inside the callback escaped the method's `try/catch`.

Fix: read with `await fs.promises.readFile` (so read/parse errors hit the `catch`) and `await` each insert in a `for...of` loop. I chose sequential over `Promise.all` deliberately — `data/users.json` is 34 MB (tens of thousands of users), and firing that many concurrent inserts would swamp the cluster; correctness (all users land) is the actual ask here, not throughput.

## Verification — live 4-node ring

Ran the issue's repro with `data/tinyUsers.json` (99 users, ids 2–102):

- `bulkInsert --path ./data/tinyUsers.json` → client reported **99/99** "inserted successfully" and took **6.2s** (it actually waited, vs. exiting instantly before).
- Looked up a spread via fresh client processes — **all found**, including the first and last:
  - id=2 → Geoff Dalgas · id=27 → Rebecca Chernoff · id=52 → Tyler Crompton · id=78 → Sim · **id=102 → Mattia Folcarelli**
  - id=102 is the last user in the file — exactly the late insert the old fire-and-forget loop dropped.
- `npm run typecheck` clean · `npm test` 6/6 · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
