### PR TITLE
Cache gRPC channels per host:port in connect() (closes #172)

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -252,6 +252,8 @@ export function handleGRPCErrors(
       );
       break;
     case 14:
+      // Drop the dead node's cached channel so the next connect() rebuilds it.
+      channelCache.delete(`${host}:${port}`);
       logger.warn(
         { scope, call, target },
         `${scope}: Unable to connect to ${target}`,
@@ -317,10 +319,18 @@ export function loadTlsCredentials(): {
   };
 }
 
+// Reuse one promisified gRPC client per host:port. Creating a client opens a
+// TCP (and, with certs, TLS) connection, and connect() runs before every
+// outbound RPC — in a multi-node ring that is dozens of new channels per
+// second. Entries are evicted by handleGRPCErrors on an UNAVAILABLE (code 14)
+// result so a dead node doesn't linger in the cache (issue #172).
+const channelCache = new Map<string, ReturnType<typeof promisifyClient>>();
+
 /**
  * Creates a gRPC client for the Node service with promisified unary methods.
  * Server-streaming methods (getFingerTableEntries, getUserIds) and
  * client-streaming methods (bulkInsertUsersRemoteHelper) remain unwrapped.
+ * Clients are cached per host:port and reused (see channelCache above).
  *
  * Uses TLS when certs/ca.crt exists; falls back to insecure transport
  * (useful for environments where certs have not been generated yet).
@@ -334,6 +344,10 @@ export function connect({
 }) {
   if (!host || !port)
     throw new Error(`Cannot connect: null node (host=${host}, port=${port})`);
+  const key = `${host}:${port}`;
+  const cached = channelCache.get(key);
+  if (cached) return cached;
+
   const tls = loadTlsCredentials();
   const credentials = tls
     ? grpc.credentials.createSsl(tls.ca)
@@ -341,12 +355,10 @@ export function connect({
   const channelOptions = tls
     ? { "grpc.ssl_target_name_override": TLS_TARGET_NAME }
     : {};
-  const raw = new chordProto.Node(
-    `${host}:${port}`,
-    credentials,
-    channelOptions,
-  );
-  return promisifyClient(raw);
+  const raw = new chordProto.Node(key, credentials, channelOptions);
+  const client = promisifyClient(raw);
+  channelCache.set(key, client);
+  return client;
 }
 
 function promisifyClient(client: any) {

--- a/test/connect-cache.test.ts
+++ b/test/connect-cache.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import pino from "pino";
+import { connect, handleGRPCErrors } from "../app/utils.ts";
+
+// Regression tests for #172: connect() must reuse one gRPC client per
+// host:port and evict it when handleGRPCErrors sees UNAVAILABLE (code 14).
+// gRPC clients are lazy (no connection until an RPC), so creating them with
+// bogus hosts is fine; we compare references and close them afterwards.
+const silent = pino({ level: "silent" });
+
+test("connect() returns the same cached client for the same host:port", () => {
+  const a = connect({ host: "cache-test-1", port: 1111 });
+  const b = connect({ host: "cache-test-1", port: 1111 });
+  assert.equal(a, b, "same host:port should return the identical client");
+  a.close?.();
+});
+
+test("connect() returns distinct clients for different host:port", () => {
+  const a = connect({ host: "cache-test-2", port: 2222 });
+  const b = connect({ host: "cache-test-2", port: 3333 });
+  assert.notEqual(a, b, "different host:port should return different clients");
+  a.close?.();
+  b.close?.();
+});
+
+test("handleGRPCErrors evicts the cached client on UNAVAILABLE (code 14)", () => {
+  const before = connect({ host: "cache-test-3", port: 4444 });
+  handleGRPCErrors(silent, "test", "ping", "cache-test-3", 4444, { code: 14 });
+  const after = connect({ host: "cache-test-3", port: 4444 });
+  assert.notEqual(before, after, "code 14 should evict, forcing a new client");
+  before.close?.();
+  after.close?.();
+});
+
+test("handleGRPCErrors does not evict on non-UNAVAILABLE errors", () => {
+  const before = connect({ host: "cache-test-4", port: 5555 });
+  handleGRPCErrors(silent, "test", "ping", "cache-test-4", 5555, { code: 5 });
+  const after = connect({ host: "cache-test-4", port: 5555 });
+  assert.equal(before, after, "non-14 errors should leave the cache intact");
+  before.close?.();
+});


### PR DESCRIPTION
## What & why

Closes #172. `connect()` built a fresh `chordProto.Node` stub on every call, and it runs before every outbound RPC. Each stub opens a TCP (and, with certs, TLS) connection whose internal pool is discarded as soon as the stub is GC'd — so in a multi-node ring, `stabilize` (every 1s) and `fixFingers` (every 3s) alone churn dozens of channels per second. It also re-read the three cert files from disk on every call via `loadTlsCredentials()`.

Fix: a module-level `Map<"host:port", client>`. `connect()` builds a channel once and returns the cached one thereafter. `handleGRPCErrors` evicts the entry on an `UNAVAILABLE` (code 14) result, so a dead node's channel is rebuilt on the next attempt instead of lingering.

Notes:
- gRPC-js channels multiplex concurrent calls, so a single shared client is safe under the ring's concurrent `stabilize`/`fixFingers` traffic.
- I evict but don't `.close()` the stale channel — a code-14 channel has already torn down its transport, and closing introduces a double-close race when several in-flight calls to the same dead node all report 14. Delete-and-GC matches the issue's suggestion; happy to add explicit `close()` if you'd prefer.

## Verification

**Unit tests** (`test/connect-cache.test.ts`) — deterministic, no live server (gRPC clients are lazy), all green:
- same `host:port` → **identical** client (reused),
- different `host:port` → distinct clients,
- `handleGRPCErrors(..., code: 14)` → next `connect()` returns a **new** client (evicted),
- other error codes → cache intact.

`npm run typecheck` clean · `npm test` 10/10 · prettier clean.

**Live 4-node ring** (`docker compose up --scale node_secondary=3`) — correctness under heavy reuse:
- Ring formed (remote successor + predecessor) — `stabilize`/`fixFingers` hammer `connect()` continuously and the cached channels handle it fine.
- `insert --id 21` / `lookup --id 21` route correctly through cached remote channels.
- Swept every node's logs — no connection/channel errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
