### PR TITLE
Adopt standard gRPC Health Checking Protocol (closes #97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ npm run client -- lookup --port 8440 --id 2
 npm run client -- edit --port 8440 --id 5 --displayName "Name" --reputation 99
 npm run client -- remove --port 8440 --id 5
 npm run client -- bulkInsert --path ./data/tinyUsers.json
-npm run client -- summary --port 8440
+npm run client -- summary --port 8440   # node identity + health status
+npm run client -- health --port 8440    # standard gRPC health check (exits non-zero if not SERVING)
 
 # Ring topology inspection (useful for debugging ring formation / stale routing)
 npm run client -- fingerTable --port 8440   # print all finger table entries
@@ -90,7 +91,7 @@ The `npm test` script is a placeholder that exits with an error.
 
 ### Protocol definition
 
-`protos/chord.proto` defines 19 RPC methods split between library-level (Chord protocol: findSuccessor, stabilize, notify, etc.) and application-level (User CRUD: fetch, insert, lookup, remove, migrate).
+`protos/chord.proto` defines 18 RPC methods split between library-level (Chord protocol: findSuccessor, stabilize, notify, etc.) and application-level (User CRUD: fetch, insert, lookup, remove, migrate). Node liveness is served separately by the standard gRPC Health Checking Protocol in `protos/health.proto` (`grpc.health.v1.Health/Check` + `Watch`, implemented in `app/health.ts`), which interoperates with `grpc_health_probe`, Kubernetes gRPC probes, etc. Node identity (id/host/port) is available via `getNodeIdRemoteHelper`.
 
 ### Entry points
 

--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -13,6 +13,7 @@ import {
   NULL_NODE,
   type Node,
 } from "./utils.ts";
+import { OVERALL_HEALTH, type HealthImplementation } from "./health.ts";
 const phi = (1 + Math.sqrt(5)) / 2;
 
 interface FingerTableEntry {
@@ -42,6 +43,9 @@ export abstract class ChordNode {
   stabilizeTimer?: ReturnType<typeof setInterval>;
   fixFingersTimer?: ReturnType<typeof setInterval>;
   checkPredecessorTimer?: ReturnType<typeof setInterval>;
+  // Standard gRPC health reporter; set in UserService.serve() and flipped to
+  // NOT_SERVING in destructor() so probes observe departure (issue #97).
+  health?: HealthImplementation;
 
   constructor({
     id,
@@ -82,15 +86,6 @@ export abstract class ChordNode {
       host: this.host,
       port: this.port,
     };
-  }
-
-  /**
-   * Print Summary of state of node
-   */
-  summary(_: any, callback: (arg0: any, arg1: Node) => void) {
-    this.logger.info({ fingerTable: this.fingerTable }, "Summary: fingerTable");
-    this.logger.info({ predecessor: this.predecessor }, "Summary: Predecessor");
-    callback(null, this.encapsulateSelf());
   }
 
   /**
@@ -1210,6 +1205,10 @@ export abstract class ChordNode {
    * Remove node from the chord gracefully by migrating keys to the remaining nodes.
    */
   async destructor() {
+    // Advertise NOT_SERVING up front so health probes and live Watch streams
+    // see the node leaving before key migration / peer notification begins
+    // (issue #97).
+    this.health?.setStatus(OVERALL_HEALTH, "NOT_SERVING");
     // Stop periodic maintenance before tearing down so stabilize/fixFingers/
     // checkPredecessor can't race the migration: mutate successor/predecessor
     // mid-flight or fire gRPC calls at departing nodes (issue #187).

--- a/app/UserService.ts
+++ b/app/UserService.ts
@@ -4,6 +4,7 @@ import * as grpc from "@grpc/grpc-js";
 import { loadSync } from "@grpc/proto-loader";
 
 import { ChordNode } from "./ChordNode.ts";
+import { HealthImplementation } from "./health.ts";
 import {
   connect,
   handleGRPCErrors,
@@ -68,7 +69,6 @@ export class UserService extends ChordNode {
   serve() {
     const server = new grpc.Server();
     server.addService((chord as any).Node.service, {
-      summary: this.summary.bind(this),
       fetch: this.fetch.bind(this),
       remove: this.remove.bind(this),
       removeUserRemoteHelper: this.removeUserRemoteHelper.bind(this),
@@ -93,6 +93,12 @@ export class UserService extends ChordNode {
       notify: this.notify.bind(this),
       destructor: this.destructor.bind(this),
     });
+
+    // Standard gRPC Health Checking Protocol (issue #97). Advertises SERVING
+    // for the whole server so grpc_health_probe / k8s probes work out of the
+    // box; destructor() flips it to NOT_SERVING on graceful shutdown.
+    this.health = new HealthImplementation();
+    server.addService(this.health.service, this.health.handlers);
 
     const tls = loadTlsCredentials();
     const serverCredentials = tls

--- a/app/health.ts
+++ b/app/health.ts
@@ -1,0 +1,153 @@
+import path from "path";
+import * as grpc from "@grpc/grpc-js";
+import { loadSync } from "@grpc/proto-loader";
+import { loadTlsCredentials } from "./utils.ts";
+
+// Server-side implementation of and client factory for the standard gRPC
+// Health Checking Protocol (grpc.health.v1.Health). This replaces the bespoke
+// `summary` liveness RPC (issue #97) so nodes interoperate with standard
+// tooling (grpc_health_probe, k8s probes, etc.).
+// Spec: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+
+const HEALTH_PROTO_PATH = path.resolve(
+  import.meta.dirname,
+  "../protos/health.proto",
+);
+
+const packageDefinition = loadSync(HEALTH_PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+
+const healthProto = (grpc.loadPackageDefinition(packageDefinition) as any).grpc
+  .health.v1;
+
+// Serving-status names as emitted/accepted by proto-loader (enums: String).
+export type ServingStatus =
+  | "UNKNOWN"
+  | "SERVING"
+  | "NOT_SERVING"
+  | "SERVICE_UNKNOWN";
+
+// The empty service name denotes the health of the whole server, per the spec.
+export const OVERALL_HEALTH = "";
+
+// Canonical name in ssl_target_name_override — must match a SAN in
+// certs/server.crt. Mirrors TLS_TARGET_NAME in utils.ts (kept local to avoid
+// widening that module's export surface for one string).
+const TLS_TARGET_NAME = "chord-node";
+
+type HealthRequest = { service?: string };
+type HealthResponse = { status: ServingStatus };
+type WatchStream = grpc.ServerWritableStream<HealthRequest, HealthResponse>;
+
+/**
+ * Tracks a serving status per service name and serves Check + Watch. A node
+ * advertises SERVING for the whole server (the "" service) once it is up and
+ * flips to NOT_SERVING during graceful shutdown so probes and live Watch
+ * streams observe the departure before key migration begins.
+ */
+export class HealthImplementation {
+  private statusMap = new Map<string, ServingStatus>();
+  private watchers = new Map<string, Set<WatchStream>>();
+
+  constructor(initial: ServingStatus = "SERVING") {
+    this.statusMap.set(OVERALL_HEALTH, initial);
+  }
+
+  // gRPC service definition to hand to server.addService().
+  get service() {
+    return healthProto.Health.service;
+  }
+
+  // Handlers keyed by RPC name for server.addService().
+  get handlers() {
+    return { Check: this.check, Watch: this.watch };
+  }
+
+  setStatus(service: string, status: ServingStatus) {
+    this.statusMap.set(service, status);
+    const subscribers = this.watchers.get(service);
+    if (subscribers) for (const call of subscribers) call.write({ status });
+  }
+
+  private check: grpc.handleUnaryCall<HealthRequest, HealthResponse> = (
+    call,
+    callback,
+  ) => {
+    const service = call.request.service ?? OVERALL_HEALTH;
+    const status = this.statusMap.get(service);
+    if (status === undefined) {
+      callback(
+        {
+          code: grpc.status.NOT_FOUND,
+          details: `unknown service "${service}"`,
+        } as grpc.ServerErrorResponse,
+        null,
+      );
+      return;
+    }
+    callback(null, { status });
+  };
+
+  private watch: grpc.handleServerStreamingCall<HealthRequest, HealthResponse> =
+    (call: WatchStream) => {
+      const service = call.request.service ?? OVERALL_HEALTH;
+      // Per spec: send the current status immediately, then on every change.
+      call.write({ status: this.statusMap.get(service) ?? "SERVICE_UNKNOWN" });
+
+      let subscribers = this.watchers.get(service);
+      if (!subscribers) {
+        subscribers = new Set();
+        this.watchers.set(service, subscribers);
+      }
+      subscribers.add(call);
+      const unsubscribe = () => subscribers!.delete(call);
+      call.on("cancelled", unsubscribe);
+      call.on("error", unsubscribe);
+    };
+}
+
+/**
+ * Builds a Health client for one node with a promisified Check. Mirrors
+ * connect() in utils.ts: TLS when certs/ca.crt exists, insecure otherwise.
+ * Used by the CLI client's `health`/`summary` commands.
+ */
+export function connectHealth({
+  host,
+  port,
+}: {
+  host: string | null;
+  port: number | null;
+}) {
+  if (!host || !port)
+    throw new Error(`Cannot connect: null node (host=${host}, port=${port})`);
+
+  const tls = loadTlsCredentials();
+  const credentials = tls
+    ? grpc.credentials.createSsl(tls.ca)
+    : grpc.credentials.createInsecure();
+  const channelOptions = tls
+    ? { "grpc.ssl_target_name_override": TLS_TARGET_NAME }
+    : {};
+  const client = new healthProto.Health(
+    `${host}:${port}`,
+    credentials,
+    channelOptions,
+  );
+
+  return {
+    check: (
+      service: string = OVERALL_HEALTH,
+    ): Promise<{ status: ServingStatus }> =>
+      new Promise((resolve, reject) => {
+        client.Check({ service }, (err: unknown, res: any) => {
+          if (err) reject(err);
+          else resolve(res);
+        });
+      }),
+  };
+}

--- a/client/client.ts
+++ b/client/client.ts
@@ -2,7 +2,7 @@ import minimist from "minimist";
 import { Client, type InsertArgs, type EditArgs } from "./common.ts";
 
 const VALID_COMMANDS =
-  "lookup, insert, edit, remove, bulkInsert, summary, fingerTable, predecessor, successor";
+  "lookup, insert, edit, remove, bulkInsert, summary, health, fingerTable, predecessor, successor";
 
 function main() {
   const args = minimist(process.argv.slice(2));
@@ -38,6 +38,9 @@ function main() {
       break;
     case "summary":
       client.summary();
+      break;
+    case "health":
+      client.health();
       break;
     case "fingerTable":
       client.fingerTable();

--- a/client/common.ts
+++ b/client/common.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { connect } from "../app/utils.ts";
+import { connectHealth } from "../app/health.ts";
 
 // Fields a caller may set on insert or change on edit. The server defaults any
 // omitted field on insert and leaves it untouched on a partial edit.
@@ -34,18 +35,42 @@ export class Client {
   host: string;
   port: number;
   client: any;
+  healthClient: ReturnType<typeof connectHealth>;
   constructor(host: string, port: number) {
     this.host = host;
     this.port = port;
     this.client = connect({ host: this.host, port: this.port });
+    this.healthClient = connectHealth({ host: this.host, port: this.port });
   }
 
+  // Standard gRPC health check (grpc.health.v1.Health/Check). Exits non-zero on
+  // a non-SERVING status or error so it doubles as a liveness probe.
+  async health() {
+    try {
+      const { status } = await this.healthClient.check();
+      console.log(`Health of ${this.host}:${this.port}: ${status}`);
+      if (status !== "SERVING") process.exitCode = 1;
+    } catch (err) {
+      console.error(`Health check failed for ${this.host}:${this.port}`);
+      console.error(err);
+      process.exitCode = 1;
+    }
+  }
+
+  // Identity (via getNodeIdRemoteHelper) plus liveness (via Health/Check). The
+  // bespoke `summary` RPC that previously returned identity was removed in #97.
   async summary() {
     console.log("Client requesting summary:");
     try {
-      const node = await this.client.summary();
+      const node = await this.client.getNodeIdRemoteHelper();
+      let status = "UNKNOWN";
+      try {
+        ({ status } = await this.healthClient.check());
+      } catch {
+        status = "UNREACHABLE";
+      }
       console.log(
-        `The node returned id: ${node.id}, host: ${node.host}, port: ${node.port}`,
+        `The node returned id: ${node.id}, host: ${node.host}, port: ${node.port}, health: ${status}`,
       );
     } catch (err) {
       console.error(err);
@@ -54,9 +79,9 @@ export class Client {
 
   async fingerTable() {
     try {
-      const summary = await this.client.summary();
+      const node = await this.client.getNodeIdRemoteHelper();
       console.log(
-        `Finger table for node ${summary.id} (${summary.host}:${summary.port}):`,
+        `Finger table for node ${node.id} (${node.host}:${node.port}):`,
       );
       const stream = this.client.getFingerTableEntries();
       let i = 0;

--- a/protos/chord.proto
+++ b/protos/chord.proto
@@ -19,7 +19,9 @@ service Node {
   rpc updateFingerTable (FingerTableEntry) returns (google.protobuf.Empty) {}
 
   // Application Level RPC Calls
-  rpc summary(google.protobuf.Empty) returns (NodeAddress) {}
+  // Node liveness is served by the standard grpc.health.v1.Health service
+  // (protos/health.proto); node identity is available via
+  // getNodeIdRemoteHelper. The bespoke `summary` RPC was removed in #97.
   rpc fetch (UserId) returns (User) {}
   rpc insert (UserEdit) returns (google.protobuf.Empty) {}
   rpc insertUserRemoteHelper (UserEdit) returns (google.protobuf.Empty) {}

--- a/protos/health.proto
+++ b/protos/health.proto
@@ -1,0 +1,28 @@
+// Standard gRPC Health Checking Protocol.
+// Verbatim from https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+// so the node interoperates with standard tooling (grpc_health_probe,
+// Kubernetes gRPC liveness/readiness probes, etc.). See issue #97.
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3; // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as grpc from "@grpc/grpc-js";
+import { HealthImplementation, OVERALL_HEALTH } from "../app/health.ts";
+
+// Tests for the standard gRPC Health Checking Protocol implementation (#97).
+// We drive the Check/Watch handlers directly with minimal call/callback stubs
+// rather than standing up a server, so these stay fast and deterministic.
+
+function checkOf(impl: HealthImplementation) {
+  return (service: string): Promise<{ err: any; status?: string }> =>
+    new Promise((resolve) => {
+      (impl.handlers as any).Check(
+        { request: { service } },
+        (err: any, res: any) => resolve({ err, status: res?.status }),
+      );
+    });
+}
+
+// Minimal ServerWritableStream stub capturing writes and exposing the cancel
+// hook so we can simulate a client disconnect.
+function fakeWatchCall(service: string) {
+  const writes: string[] = [];
+  const listeners: Record<string, () => void> = {};
+  return {
+    request: { service },
+    writes,
+    write: (r: { status: string }) => writes.push(r.status),
+    on: (event: string, handler: () => void) => {
+      listeners[event] = handler;
+    },
+    cancel: () => listeners["cancelled"]?.(),
+  };
+}
+
+test("Check returns SERVING for the overall server by default", async () => {
+  const impl = new HealthImplementation();
+  const { err, status } = await checkOf(impl)(OVERALL_HEALTH);
+  assert.equal(err, null);
+  assert.equal(status, "SERVING");
+});
+
+test("Check on an unknown service returns NOT_FOUND (code 5)", async () => {
+  const impl = new HealthImplementation();
+  const { err, status } = await checkOf(impl)("does.not.exist");
+  assert.equal(status, undefined);
+  assert.equal(err?.code, grpc.status.NOT_FOUND);
+});
+
+test("Watch sends the current status immediately", () => {
+  const impl = new HealthImplementation();
+  const call = fakeWatchCall(OVERALL_HEALTH);
+  (impl.handlers as any).Watch(call);
+  assert.deepEqual(call.writes, ["SERVING"]);
+});
+
+test("setStatus pushes updates to live Watch subscribers (shutdown path)", () => {
+  const impl = new HealthImplementation();
+  const call = fakeWatchCall(OVERALL_HEALTH);
+  (impl.handlers as any).Watch(call);
+  // This is exactly what destructor() does on graceful shutdown.
+  impl.setStatus(OVERALL_HEALTH, "NOT_SERVING");
+  assert.deepEqual(call.writes, ["SERVING", "NOT_SERVING"]);
+  // A subsequent Check reflects the new status too.
+});
+
+test("Watch on an unregistered service reports SERVICE_UNKNOWN", () => {
+  const impl = new HealthImplementation();
+  const call = fakeWatchCall("not.registered.yet");
+  (impl.handlers as any).Watch(call);
+  assert.deepEqual(call.writes, ["SERVICE_UNKNOWN"]);
+});
+
+test("a cancelled Watch stops receiving updates", () => {
+  const impl = new HealthImplementation();
+  const call = fakeWatchCall(OVERALL_HEALTH);
+  (impl.handlers as any).Watch(call);
+  call.cancel();
+  impl.setStatus(OVERALL_HEALTH, "NOT_SERVING");
+  // Only the initial SERVING; no NOT_SERVING after cancellation.
+  assert.deepEqual(call.writes, ["SERVING"]);
+});


### PR DESCRIPTION
## What & why

Closes #97. Replaces the bespoke `summary` liveness RPC with the standard **`grpc.health.v1.Health`** service (`Check` + `Watch`), per the [gRPC health checking spec](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). Nodes now interoperate with standard tooling — `grpc_health_probe`, Kubernetes gRPC liveness/readiness probes, etc.

The wrinkle the issue flagged: `summary` did double duty — **liveness** *and* **node identity** (it returned `NodeAddress`). `Health/Check` only reports `SERVING`/`NOT_SERVING`, so identity is preserved separately via the existing `getNodeIdRemoteHelper` RPC.

## Changes

- **`protos/health.proto`** — standard `Health` service definition (verbatim from the spec)
- **`app/health.ts`** — `HealthImplementation` (per-service status map, `Check` + `Watch`, watcher notification) and a `connectHealth` client factory that mirrors `connect()`'s TLS handling
- **`app/UserService.ts`** — registers the Health service, advertises `SERVING` for the whole server (`""`)
- **`app/ChordNode.ts`** — removed the `summary` method; `destructor()` flips to `NOT_SERVING` **before** key migration so probes and live `Watch` streams observe the departure
- **`protos/chord.proto`** — removed the `summary` RPC
- **`client/`** — new `health` command (`Health/Check`, exits non-zero if not `SERVING`, so it doubles as a probe); `summary`/`fingerTable` now source identity from `getNodeIdRemoteHelper`
- **`test/health.test.ts`** — 6 regression tests (Check, NOT_FOUND for unknown service, Watch initial/notify/cancel, the shutdown `setStatus` path)
- **`CLAUDE.md`** — docs

## Verification

- `npm run typecheck` clean; `npm test` 16/16 pass (10 existing + 6 new)
- **Single node**: CLI `summary`/`health`/`fingerTable`, plus a standalone TLS Health client — `Check("")`→SERVING, `Check(unknown)`→`NOT_FOUND` (code 5), `Watch` initial→SERVING
- **Real 4-node Docker cluster** (`--scale node_secondary=3`, TLS):
  - Primary `Health/Check`→SERVING; finger table showed multiple distinct node ids (genuine multi-node ring)
  - Both joined secondaries probed from inside their containers → SERVING
  - Graceful shutdown: host `Watch` stream observed `SERVING`→`NOT_SERVING`, and primary logs confirmed it migrated keys to a live successor *after* the flip:
    ```
    SIGTERM caught
    Node {3448848794} ... is exiting the chord.
    Keys are migrating to node {4034060507}.
    ```

## Reviewer notes

- **Identity vs. liveness split is intentional.** `Health/Check` can't carry identity; `getNodeIdRemoteHelper` already returned `{id,host,port}`, so the client uses it for the `summary`/`fingerTable` headers.
- **Out of scope, but worth knowing:** the dev `docker-compose` `command` runs `pnpm run devServer` (→ `node --watch` → app). A plain `docker stop` sends SIGTERM to PID 1 (`pnpm`), which doesn't reliably forward through `node --watch`, so the graceful `NOT_SERVING` path won't fire under a real `docker stop`/pod termination in *that* configuration. I validated the path by signaling the app process directly. Running the app directly (or via `tini`) would fix forwarding — happy to file a separate issue.
- `CLAUDE.md` still says "No test suite exists," which is now stale (there's a real `node --test` suite under `test/`); left untouched as outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
