### PR TITLE
docs: use pnpm in setup instructions, not npm (closes #199)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,15 @@ Chord-gRPC is a peer-to-peer distributed hash table (DHT) implementing the Chord
 ### Running with Docker (preferred)
 
 ```bash
-npm install
-npm run gen-certs                                  # generate local TLS certs (see TLS note below)
+pnpm install
+pnpm run gen-certs                                  # generate local TLS certs (see TLS note below)
 docker-compose up --scale node_secondary=5 -d    # Start cluster
 docker-compose up --scale node_secondary=8 -d     # Scale out
 docker-compose down                                # Stop cluster
 ```
 
 **TLS:** The `certs/` directory is developer-local and gitignored (#185) — never
-commit keys. Run `npm run gen-certs` (`scripts/gen-certs.sh`, needs OpenSSL 3.x)
+commit keys. Run `pnpm run gen-certs` (`scripts/gen-certs.sh`, needs OpenSSL 3.x)
 to create a fresh CA + server cert. When `certs/ca.crt` is absent,
 `loadTlsCredentials()` in `app/utils.ts` returns `null` and nodes/clients fall
 back to insecure transport, so the cluster still runs without certs.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ In the future, the project will implement a "Stack Exchange Computer Science Use
 
 ## To Run
 
-We assume that you have Node.js, Docker, and Docker-Compose installed. You can confirm this with `node -v`, `docker -v`, and `docker-compose -v`
+We assume that you have Node.js, Docker, and Docker-Compose installed. You can confirm this with `node -v`, `docker -v`, and `docker-compose -v`.
+
+This project uses **pnpm** (declared via `"packageManager"` in `package.json`, with a `pnpm-lock.yaml` lockfile; CI and the Docker images use it too). Install it with Corepack, which ships with Node — `corepack enable` — or directly with `npm install -g pnpm`. Using `npm install` here bypasses the lockfile and can resolve different dependency versions.
 
 ```
 git clone git@github.com:bushidocodes/chord-grpc.git
 cd chord-grpc
-npm install
-npm run gen-certs   # generate developer-local TLS certs (optional, see below)
+pnpm install
+pnpm run gen-certs   # generate developer-local TLS certs (optional, see below)
 docker-compose up --scale node_secondary=5 -d
 ```
 
@@ -29,7 +31,7 @@ Then open localhost:1337 in a browser
 
 Inter-node gRPC traffic is encrypted with TLS when certificates are present in
 `certs/`. These are **developer-local and are not committed to the repo** — run
-`npm run gen-certs` (a thin wrapper around `scripts/gen-certs.sh`, which needs
+`pnpm run gen-certs` (a thin wrapper around `scripts/gen-certs.sh`, which needs
 OpenSSL 3.x) to generate a fresh CA and server certificate. If `certs/` is empty
 the cluster still runs, but over **insecure** transport — fine for local
 experimentation, not for anything exposed. Regenerate certs on every machine
@@ -38,7 +40,7 @@ that builds or runs the cluster.
 Then run the following command in a separate tab to seed the sample StackOverflow data:
 
 ```
-npm run client -- bulkInsert --path ./data/tinyUsers.json
+pnpm run client -- bulkInsert --path ./data/tinyUsers.json
 ```
 
 You can then use the Data API as documented in `commands.md`


### PR DESCRIPTION
## What & why

Closes #199. The project is **pnpm-based** — `"packageManager": "pnpm@11.5.0"`, a `pnpm-lock.yaml` lockfile, and both CI (`pnpm install --frozen-lockfile`) and the Docker images use pnpm — but the README's first setup step was `npm install`. That bypasses the lockfile (and can error under Corepack enforcement), so a new contributor following the README couldn't reliably set the project up.

## Changes

- **README.md**: `npm install` → `pnpm install`; `npm run …` → `pnpm run …`; added a short note on getting pnpm (Corepack `corepack enable`, or `npm install -g pnpm`) and why plain `npm install` is wrong here.
- **CLAUDE.md**: same fix in the Docker setup block + TLS note — the only other `npm install` in the docs.

**Scope note:** I changed only the `npm install` (the actual lockfile-bypass defect) and the commands in the affected blocks. The `npm run <script>` examples elsewhere in CLAUDE.md were left alone — those execute the package.json scripts fine regardless of package manager, so converting them all would be churn beyond this issue. `commands.md` has no `npm install` and needed no change.

## Verification (by execution)

- `pnpm install --frozen-lockfile` (exactly what CI runs) → "Already up to date" (lockfile valid, no drift)
- `pnpm run gen-certs` → regenerates `certs/` correctly
- `pnpm run client` → dispatches the CLI (prints usage)
- `prettier --check` clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
