### PR TITLE
fix(client): bulkInsert fails fast on connection error instead of spamming stack traces (closes #206)

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -31,6 +31,15 @@ export type InsertArgs = { id: number } & Partial<EditableFields>;
 // Edit needs an id plus at least one editable field to patch.
 export type EditArgs = { id: number } & AtLeastOne<EditableFields>;
 
+// True when the node is unreachable: gRPC UNAVAILABLE (14) or a raw
+// ECONNREFUSED bubbling up. Used by bulkInsert to fail fast instead of
+// re-attempting every record against a node that won't recover (issue #206).
+export function isConnectionError(err: unknown): boolean {
+  if ((err as { code?: number })?.code === 14) return true;
+  const message = String((err as { message?: unknown })?.message ?? "");
+  return /ECONNREFUSED|No connection established/i.test(message);
+}
+
 export class Client {
   host: string;
   port: number;
@@ -160,7 +169,25 @@ export class Client {
       process.exit();
     }
 
-    const user = {
+    try {
+      await this.client.insert({ user: this.buildUser(args), edit: false });
+      console.log("User inserted successfully");
+    } catch (err) {
+      const grpcErr = err as { code?: number };
+      switch (grpcErr.code) {
+        case 6:
+          console.log("User already exists!");
+          break;
+        default:
+          console.log("User insertion error:", err);
+      }
+    }
+  }
+
+  // Builds the wire User from CLI args, applying defaults for omitted fields.
+  // Shared by insert() and bulkInsert().
+  private buildUser(args: InsertArgs) {
+    return {
       id: args.id,
       reputation: args.reputation || 0,
       creationDate: args.creationDate || Date.now().toString(),
@@ -175,19 +202,6 @@ export class Client {
       profileImageUrl: args.profileImageUrl || "",
       accountId: args.accountId || 0,
     };
-    try {
-      await this.client.insert({ user, edit: false });
-      console.log("User inserted successfully");
-    } catch (err) {
-      const grpcErr = err as { code?: number };
-      switch (grpcErr.code) {
-        case 6:
-          console.log("User already exists!");
-          break;
-        default:
-          console.log("User insertion error:", err);
-      }
-    }
   }
 
   async edit(args: EditArgs) {
@@ -241,22 +255,56 @@ export class Client {
       console.log("bulkInsert requires a path to a JSON file");
       process.exit();
     }
+
+    let users: InsertArgs[];
     try {
       const jsonPath = path.resolve(import.meta.dirname, "..", args.path);
-      console.log(jsonPath);
       const rawData = await fs.promises.readFile(jsonPath, "utf8");
-      const data = JSON.parse(rawData);
-      const users: InsertArgs[] = Object.values(data);
-      // Await each insert sequentially so every user lands before the client
-      // exits — the old forEach fired the async inserts and returned, tearing
-      // down the process first. Sequential (vs Promise.all) also avoids firing
-      // tens of thousands of concurrent inserts at the cluster for users.json.
-      for (const user of users) {
-        await this.insert(user);
-      }
+      users = Object.values(JSON.parse(rawData));
     } catch (err) {
+      console.error(`bulkInsert: could not read users from ${args.path}`);
       console.error(err);
+      process.exitCode = 1;
+      return;
     }
+
+    // Insert sequentially (not Promise.all) so we don't fire tens of thousands
+    // of concurrent inserts at the cluster and so the process doesn't exit
+    // before they land. On the first connection failure, fail fast: a dead node
+    // won't recover mid-loop, so attempting the remaining records would just
+    // print one identical stack trace per record (issue #206).
+    let inserted = 0;
+    let duplicates = 0;
+    for (const user of users) {
+      if (!user.id) {
+        console.warn("bulkInsert: skipping a record with no id");
+        continue;
+      }
+      try {
+        await this.client.insert({ user: this.buildUser(user), edit: false });
+        inserted++;
+      } catch (err) {
+        if (isConnectionError(err)) {
+          console.error(
+            `bulkInsert: could not connect to node at ${this.host}:${this.port} — aborting after ${inserted} insert(s).`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        const code = (err as { code?: number }).code;
+        // ALREADY_EXISTS (6) is an expected per-record outcome, not a failure.
+        if (code === 6) {
+          duplicates++;
+          continue;
+        }
+        console.error(
+          `bulkInsert: failed to insert user ${user.id} (gRPC code ${code ?? "unknown"})`,
+        );
+      }
+    }
+    console.log(
+      `bulkInsert: ${inserted} inserted, ${duplicates} already existed, ${users.length} total`,
+    );
   }
 
   async remove(args: { id?: number }) {

--- a/test/bulk-insert.test.ts
+++ b/test/bulk-insert.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isConnectionError } from "../client/common.ts";
+
+// Regression tests for #206: bulkInsert must recognise an unreachable node so
+// it can fail fast instead of printing one stack trace per record.
+
+test("isConnectionError is true for gRPC UNAVAILABLE (code 14)", () => {
+  assert.equal(isConnectionError({ code: 14 }), true);
+});
+
+test("isConnectionError is true for a raw ECONNREFUSED message", () => {
+  assert.equal(
+    isConnectionError(new Error("connect ECONNREFUSED 127.0.0.1:8440")),
+    true,
+  );
+});
+
+test("isConnectionError is true for grpc-js 'No connection established'", () => {
+  assert.equal(
+    isConnectionError({
+      code: 14,
+      message: "14 UNAVAILABLE: No connection established.",
+    }),
+    true,
+  );
+});
+
+test("isConnectionError is false for ALREADY_EXISTS (code 6)", () => {
+  assert.equal(isConnectionError({ code: 6 }), false);
+});
+
+test("isConnectionError is false for NOT_FOUND (code 5)", () => {
+  assert.equal(isConnectionError({ code: 5 }), false);
+});
+
+test("isConnectionError is false for unrelated / empty errors", () => {
+  assert.equal(isConnectionError(new Error("validation failed")), false);
+  assert.equal(isConnectionError(undefined), false);
+  assert.equal(isConnectionError(null), false);
+  assert.equal(isConnectionError({}), false);
+});


### PR DESCRIPTION
## What & why

Closes #206. When the target node is unreachable (e.g. `--port` omitted so it falls back to 8440 with nothing listening), `bulkInsert` attempted **every** record and printed a full `ECONNREFUSED` stack trace for each — hundreds of identical traces, no clean exit. It looped calling the per-record `insert()`, which swallows and logs errors, so it never noticed the node was simply down.

## Fix

`bulkInsert` now drives the gRPC insert directly and, on the **first** connection failure, prints one human-readable line, sets a non-zero exit code, and stops — a dead node won't recover mid-loop, so retrying the rest is pointless.

- `isConnectionError(err)` — gRPC `UNAVAILABLE` (14) or `ECONNREFUSED` / "No connection established" in the message. Exported and unit-tested.
- `buildUser()` — extracted from `insert()` so `bulkInsert` reuses the field-defaulting logic without the per-record logging.
- `ALREADY_EXISTS` (code 6) is treated as an expected per-record outcome (counted, not failed).
- File read/parse errors now report **once** and exit non-zero (previously dumped the raw error).
- The run ends with an `N inserted, M already existed, T total` summary instead of one `User inserted successfully` line per record.
- `test/bulk-insert.test.ts` — 6 cases for `isConnectionError`.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Node down | 99 stack traces, exit 0 | 1 line, exit 1 |
| Node up (fresh) | 99 `User inserted successfully` | `99 inserted, 0 already existed, 99 total`, exit 0 |
| Node up (re-run) | 99 `User already exists!` | `0 inserted, 99 already existed, 99 total`, exit 0 |

## Verification (by execution)

Reproduced the original spam first (99 × `code 14` traces against a dead 8440), then confirmed each row of the table above against a real TLS node. `npm run typecheck` clean, `npm test` 22/22 (16 + 6 new), `prettier --check` clean.

## Scope note

Left the single-record `insert()` CLI path's error output as-is — one stack trace for one record isn't spam, and `insert()` is a pure refactor here (now calls the shared `buildUser`, exercised by the 99 successful bulk inserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
