### PR TITLE
fix: bound successor-table grow loop by length, not index (closes #167)

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -891,9 +891,15 @@ export abstract class ChordNode {
       this.logger.debug(
         `updateSuccessorTable: Short successorTable[]: [ current length ${this.successorTable.length} ] < [ ${SUCCESSOR_TABLE_MAX_LENGTH} preferred length ]`,
       );
+      // Bound on the table length, not on `i`: each iteration appends at most
+      // one entry, so stopping when the table reaches its max keeps it from
+      // overshooting and issuing wasted getSuccessor() RPCs. (A simple
+      // `i < MAX` still overshoots to MAX+1, since the table grows as i does —
+      // see #167.) The `i < length` term guards the table[i] read.
       for (
         let i = 0;
-        i < this.successorTable.length && i <= SUCCESSOR_TABLE_MAX_LENGTH;
+        i < this.successorTable.length &&
+        this.successorTable.length < SUCCESSOR_TABLE_MAX_LENGTH;
         i++
       ) {
         try {

--- a/test/successor-table.test.ts
+++ b/test/successor-table.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { UserService } from "../app/UserService.ts";
+import { SUCCESSOR_TABLE_MAX_LENGTH, type Node } from "../app/utils.ts";
+
+// Regression test for #167: the grow phase of updateSuccessorTable() must not
+// build the successor table past SUCCESSOR_TABLE_MAX_LENGTH, nor issue more
+// getSuccessor() RPCs than needed to fill it. The old `i <= MAX` bound (and
+// even a naive `i < MAX`) overshot because the table grows as `i` advances.
+//
+// We stand up a node whose ring is a simple ascending chain (0 -> 1 -> 2 -> …)
+// and stub the three gRPC helpers updateSuccessorTable() depends on, so the
+// test is deterministic and needs no live cluster.
+
+function makeNode() {
+  const node = new UserService({ id: 0, host: "h", port: 1000 });
+  node.logger.level = "silent";
+
+  let getSuccessorCalls = 0;
+  // successor of node k is node k+1 — an endless distinct chain.
+  node.getSuccessor = async (n: Node): Promise<Node> => {
+    getSuccessorCalls++;
+    const id = (n.id as number) + 1;
+    return { id, host: "h", port: 1000 + id };
+  };
+  node.isOkSuccessor = async () => true;
+  node.confirmExist = async () => true;
+
+  const firstSuccessor: Node = { id: 1, host: "h", port: 1001 };
+  node.fingerTable = [{ start: 1, successor: firstSuccessor }];
+  node.successorTable = [firstSuccessor];
+
+  return { node, getSuccessorCalls: () => getSuccessorCalls };
+}
+
+test("updateSuccessorTable fills the table to exactly MAX, no further", async () => {
+  const { node } = makeNode();
+  await node.updateSuccessorTable();
+  assert.equal(
+    node.successorTable.length,
+    SUCCESSOR_TABLE_MAX_LENGTH,
+    "table should be filled to exactly the max length",
+  );
+});
+
+test("updateSuccessorTable never overshoots MAX during the grow phase", async () => {
+  const { node, getSuccessorCalls } = makeNode();
+  await node.updateSuccessorTable();
+  // Filling a table from length 1 to MAX needs exactly MAX-1 appends, hence
+  // MAX-1 getSuccessor() calls. The off-by-one bug made MAX+1 calls and grew
+  // the table to MAX+2 before pruning it back down.
+  assert.equal(
+    getSuccessorCalls(),
+    SUCCESSOR_TABLE_MAX_LENGTH - 1,
+    "should issue exactly MAX-1 getSuccessor RPCs (no wasted calls)",
+  );
+});
+
+test("updateSuccessorTable produces the contiguous successor chain", async () => {
+  const { node } = makeNode();
+  await node.updateSuccessorTable();
+  const ids = node.successorTable.map((n) => n.id);
+  assert.deepEqual(
+    ids,
+    Array.from({ length: SUCCESSOR_TABLE_MAX_LENGTH }, (_, k) => k + 1),
+    "table should be the ring chain 1..MAX with no duplicates or gaps",
+  );
+});


### PR DESCRIPTION
## What & why

Closes #167. The "bulk up the table" loop in `updateSuccessorTable()` was bounded by `i <= SUCCESSOR_TABLE_MAX_LENGTH`. Since each iteration appends an entry, the table grows as `i` advances — so the loop ran `MAX+1` times and grew the table to `MAX+2` entries before the prune step trimmed it back. The net effect is two wasted `getSuccessor()` RPCs per stabilization round whenever the table is short.

## The fix (and why it differs from the issue's suggestion)

The issue suggested `i < MAX`, but **that still overshoots** to `MAX+1` for the same root cause: the table grows together with `i`, so an index-based bound can't pin the final length. I bounded the loop on the **table length** instead:

```ts
i < this.successorTable.length &&
this.successorTable.length < SUCCESSOR_TABLE_MAX_LENGTH
```

This fills the table to *exactly* `MAX` and stops — which is the behavior the issue's "expected behavior" section actually asks for ("never grow beyond MAX"). The `i < length` term is retained to guard the `table[i]` read.

Walkthrough with `MAX = 8`, starting from a length-1 table:
- Old `i <= 8`: loops `i = 0..8` → 9 appends → length 10, then pruned to 8 (9 wasted-ish RPCs).
- Suggested `i < 8`: loops `i = 0..7` → length 9 (still over by one).
- This PR (`length < 8`): appends until length hits 8 → 7 appends, then stops. Exactly MAX, MAX-1 RPCs.

## Verification (by execution)

Added `test/successor-table.test.ts`, which stubs the three gRPC helpers (`getSuccessor`, `isOkSuccessor`, `confirmExist`) with a synthetic ascending ring so the test is deterministic and needs no cluster. It asserts:
- the table fills to **exactly** `MAX`,
- it issues **exactly `MAX-1`** `getSuccessor` calls (the regression guard),
- the result is the contiguous chain `1..MAX` (no dupes/gaps).

I confirmed the call-count assertion **fails on the old `i <= MAX` bound** (9 calls vs expected 7) and **passes with the fix**. Full suite: `npm test` 25/25 (22 + 3 new), `typecheck` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
