### PR TITLE
fix(docker): run chord nodes directly so SIGTERM triggers graceful shutdown (closes #208)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,38 @@ services:
       - "8440:1337"
     environment:
       - LOG_LEVEL=info
-    command: "pnpm run devServer --host node_primary --knownHost node_primary --knownPort 1337"
+    # Run the node process directly (exec form) under an init, NOT via
+    # `pnpm run devServer` (= `node --watch ./app/node.ts`). pnpm-as-PID-1 and
+    # node --watch's child both swallow SIGTERM, so `docker stop` never reached
+    # the app's graceful-shutdown handler — keys weren't migrated and health
+    # never flipped to NOT_SERVING (#208). init: true reaps + forwards signals.
+    # --watch is also pointless here: the source is baked in, not mounted.
+    init: true
+    command:
+      - node
+      - ./app/node.ts
+      - --host
+      - node_primary
+      - --knownHost
+      - node_primary
+      - --knownPort
+      - "1337"
   node_secondary:
     build:
       context: .
       dockerfile: NodeDockerfile
     environment:
       - LOG_LEVEL=info
-    command: "pnpm run devServer --knownHost node_primary --knownPort 1337"
+    # See node_primary: run the app directly under an init so SIGTERM reaches
+    # the graceful-shutdown handler (#208).
+    init: true
+    command:
+      - node
+      - ./app/node.ts
+      - --knownHost
+      - node_primary
+      - --knownPort
+      - "1337"
     depends_on:
       - node_primary
   web:


### PR DESCRIPTION
## What & why

Closes #208. The compose node services ran `pnpm run devServer` (= `node --watch ./app/node.ts`). `docker stop` sends SIGTERM to **PID 1 (`pnpm`)**, and neither `pnpm` nor `node --watch` forwards it to the leaf app process that registers the graceful-shutdown handler (`app/node.ts:118-119`). So on `docker stop` / `docker compose down` / a k8s pod termination, the destructor never ran — **keys were dropped instead of migrated to a successor, and health never flipped to `NOT_SERVING`**. (`--watch` was also a no-op for these services: the source is baked into the image, not mounted.)

## Fix

`node_primary` and `node_secondary` now run `node ./app/node.ts` **directly in exec form**, under `init: true` (Docker's tini) which reaps zombies and forwards signals. The process tree becomes `docker-init → node`, so SIGTERM reaches the app's handler.

`web` is intentionally left on `pnpm run devWeb` / `--watch`: it has a `./web` source mount (so `--watch` hot-reload is useful) and no graceful-shutdown logic, so the wrapper is harmless there.

## Verification (by execution)

On a real cluster — `docker compose up --build --scale node_secondary=2` (TLS):

- `cat /proc/1/cmdline` in the primary → `/sbin/docker-init -- docker-entrypoint.sh node ./app/node.ts …` (tini is PID 1; the entrypoint `exec`s node, so node is tini's direct child).
- Seeded 99 users, then `docker stop` the primary:
  - returned in **~1.0s**, not the 10s SIGKILL timeout
  - **exit code 0**
  - logs:
    ```
    SIGTERM caught
    Node {3448848794} ... is exiting the chord.
    Keys are migrating to node {2008017489}.
    ```

Before this change (documented in #208), the same `docker stop` left no shutdown logs and relied on the SIGKILL fallback. `docker-compose.yml` validates (`docker compose config`) and `prettier --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
