### PR TITLE
perf: memoize loadTlsCredentials so certs aren't re-read on every channel (closes #171)

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -298,25 +298,37 @@ export function withTimeout<T>(
 // Canonical name used in ssl_target_name_override — must match a SAN in certs/server.crt.
 const TLS_TARGET_NAME = "chord-node";
 
+// Cache the loaded credentials: the cert files don't change while a process
+// runs, so re-reading three files on every channel (re)creation is wasted disk
+// I/O — connect() reads them on every cache miss / post-eviction reconnect, and
+// connectHealth() reads them on every call (#171). Only the positive result is
+// cached; while certs are absent we keep returning null (a cheap existsSync) so
+// a later `gen-certs` is still picked up without restarting the process.
+let cachedTlsCredentials: { ca: Buffer; cert: Buffer; key: Buffer } | null =
+  null;
+
 /**
  * Loads TLS credentials from the certs directory (GRPC_CERTS_DIR env var, or
  * <project-root>/certs by default). Returns null when certs are absent so
- * callers can fall back to insecure transport.
+ * callers can fall back to insecure transport. The loaded result is memoized
+ * (see cachedTlsCredentials above).
  */
 export function loadTlsCredentials(): {
   ca: Buffer;
   cert: Buffer;
   key: Buffer;
 } | null {
+  if (cachedTlsCredentials) return cachedTlsCredentials;
   const certsDir =
     process.env.GRPC_CERTS_DIR ?? path.resolve(import.meta.dirname, "../certs");
   const caCert = path.join(certsDir, "ca.crt");
   if (!fs.existsSync(caCert)) return null;
-  return {
+  cachedTlsCredentials = {
     ca: fs.readFileSync(caCert),
     cert: fs.readFileSync(path.join(certsDir, "server.crt")),
     key: fs.readFileSync(path.join(certsDir, "server.key")),
   };
+  return cachedTlsCredentials;
 }
 
 // Reuse one promisified gRPC client per host:port. Creating a client opens a

--- a/test/tls-credentials.test.ts
+++ b/test/tls-credentials.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadTlsCredentials } from "../app/utils.ts";
+
+// Regression test for #171: loadTlsCredentials must not re-read the cert files
+// on every call. We assert reference stability — when certs are present, two
+// calls return the very same object, proving the read is memoized. Without the
+// cache each call builds a fresh object from fresh fs.readFileSync buffers, so
+// the references would differ. (With no certs present both calls return null,
+// which is trivially stable, so this guard is meaningful when certs exist.)
+
+test("loadTlsCredentials returns a stable (memoized) reference", () => {
+  const a = loadTlsCredentials();
+  const b = loadTlsCredentials();
+  assert.equal(a, b, "repeated calls should return the identical cached value");
+});
+
+test("loadTlsCredentials returns null or a complete {ca,cert,key} set", () => {
+  const creds = loadTlsCredentials();
+  if (creds === null) return; // insecure fallback when no certs are present
+  assert.ok(Buffer.isBuffer(creds.ca), "ca should be a Buffer");
+  assert.ok(Buffer.isBuffer(creds.cert), "cert should be a Buffer");
+  assert.ok(Buffer.isBuffer(creds.key), "key should be a Buffer");
+});


### PR DESCRIPTION
## What & why

Closes #171. `loadTlsCredentials()` read three files (`ca.crt`, `server.crt`, `server.key`) from disk on **every call**, for data that never changes while the process runs.

**Scope correction:** the issue's headline — "re-reads on every gRPC call" — is no longer accurate. The channel cache added in #172 means `connect()` returns the cached client *before* it ever calls `loadTlsCredentials()` ([`app/utils.ts`](app/utils.ts) — the `channelCache.get(key)` early-return precedes the `loadTlsCredentials()` call). So the per-RPC reads are already gone. What remains is still real, just smaller: the three files are re-read on every **cache miss / post-eviction reconnect** (evictions happen on `UNAVAILABLE`, so exactly when a ring is churning) and on every **`connectHealth()`** call (one per CLI command).

## Fix

Memoize the loaded credentials. Only the **positive** result is cached — while certs are absent we keep returning `null` (a cheap `existsSync`), so a later `npm run gen-certs` is still picked up without restarting the process. That's deliberately safer than the issue's suggested eager module-load IIFE, which would bind both the result and `GRPC_CERTS_DIR` at import time.

No behavioral change otherwise: the server already loads certs once at startup, and each cached channel already pins its credentials, so memoizing the file read just removes redundant I/O.

## Verification (by execution)

- Added `test/tls-credentials.test.ts`: asserts repeated calls return the **identical** cached object, plus that the result is `null` or a complete `{ca,cert,key}` Buffer set.
- Confirmed the stability assertion **fails on the old non-memoized code** (with certs present: two calls returned distinct objects) and **passes** with the cache.
- Live check: started a node and ran `client health` — `SERVING` over TLS using the memoized creds.
- Full suite `npm test` 27/27 (25 + 2 new), `typecheck` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
