### PR TITLE
Convert client-side scripts to ES modules (closes #215)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/xml2js": "^0.4.14",
     "husky": "^9.0.0",
     "is-ci": "^4.1.0",
-    "lodash": "^4.18.1",
     "prettier": "^3.8.4",
     "pretty-quick": "^4.0.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       is-ci:
         specifier: ^4.1.0
         version: 4.1.0
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -359,9 +356,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -942,8 +936,6 @@ snapshots:
   keycharm@0.4.0: {}
 
   lodash.camelcase@4.3.0: {}
-
-  lodash@4.18.1: {}
 
   long@5.3.2: {}
 

--- a/scripts/copy-vendor.js
+++ b/scripts/copy-vendor.js
@@ -10,14 +10,9 @@ mkdirSync(dest, { recursive: true });
 cpSync(
   resolve(
     __dirname,
-    "../node_modules/vis-network/standalone/umd/vis-network.min.js",
+    "../node_modules/vis-network/standalone/esm/vis-network.min.js",
   ),
   resolve(dest, "vis-network.min.js"),
-);
-
-cpSync(
-  resolve(__dirname, "../node_modules/lodash/lodash.min.js"),
-  resolve(dest, "lodash.min.js"),
 );
 
 console.log("Vendor files copied to web/public/vendor/");

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,9 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Chord Network</title>
-    <script src="./vendor/vis-network.min.js"></script>
-    <script src="./vendor/lodash.min.js"></script>
-    <script src="./index.js"></script>
+    <script type="module" src="./index.js"></script>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>

--- a/web/public/index.js
+++ b/web/public/index.js
@@ -1,9 +1,11 @@
+import { Network, DataSet } from "./vendor/vis-network.min.js";
+
 const CRAWLER_INTERVAL_MS = 1000;
 const HASH_SPACE = 2 ** 32;
 
 let network;
-const nodeSet = new vis.DataSet();
-const edgeSet = new vis.DataSet();
+const nodeSet = new DataSet();
+const edgeSet = new DataSet();
 
 function hashCode(str) {
   let hash = 0;
@@ -121,7 +123,7 @@ async function loadData() {
 
   const updatedNodes = nodeSet.update(nodes);
   const allNodes = nodeSet.getIds();
-  const nodesToRemove = _.difference(allNodes, updatedNodes);
+  const nodesToRemove = allNodes.filter((id) => !updatedNodes.includes(id));
   nodesToRemove.forEach((val) => nodeSet.remove(val));
 
   const updatedEdges = edgeSet.update(edges);
@@ -181,7 +183,7 @@ async function loadData() {
   };
 
   if (!network) {
-    network = new vis.Network(container, data, options);
+    network = new Network(container, data, options);
     network.on("click", function (params) {
       if (params.nodes.length > 0) {
         const nodeContent = document.getElementById("nodeContent");


### PR DESCRIPTION
Closes #215.

## What & why
The web UI loaded JS via classic `<script src>` tags sharing one global scope. This converts it to a single ES module entry point so each file has its own scope and dependencies are explicit.

## Changes
- **`web/public/index.html`** — removed the vendor + local `<script>` tags; only the module entry point remains:
  ```html
  <script type="module" src="./index.js"></script>
  ```
- **`web/public/index.js`** — `import { Network, DataSet } from "./vendor/vis-network.min.js"` instead of reading the global `vis`. `network`, `nodeSet`, and `edgeSet` are now module-scoped (no global pollution).
- **lodash dropped** — it was used for a single `_.difference(a, b)` call, replaced with `a.filter(x => !b.includes(x))`. Removed the dependency, its vendor copy, and its lockfile entry.
- **`scripts/copy-vendor.js`** — copies vis-network's **ESM** standalone build (`standalone/esm/`) instead of the UMD build, since it's now `import`ed rather than attached as a global.

> Note: vis-network stays vendored (its standalone ESM bundle is imported by relative path). It's a UMD/ESM dual-publish library; only the ESM artifact changed. There's no `lodash-es` equivalent pulled in because the one use was trivial to inline.

## Verification
Exercised end-to-end, not just eyeballed:
- **Direct run** (`node ./app/node.ts` ×3 + web server): 3-node ring renders, **0 console errors/warnings**, `window.vis`/`window._`/`window.network` all `undefined`.
- **Docker** (`docker compose build` + `up --scale node_secondary=3` with `gen-certs`): all images build (the web image runs the modified `copy-vendor.js` under `--frozen-lockfile`), nodes serve over **TLS**, 4-node ring forms, UI renders with 0 console errors, `index.js` and the vendor bundle are served as `text/javascript`, detail panel (predecessor / finger table) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)