### PR TITLE
dep: replace minimist with node:util parseArgs (closes #217)

### DIFF
--- a/app/node.ts
+++ b/app/node.ts
@@ -1,5 +1,5 @@
 import process from "process";
-import minimist from "minimist";
+import { parseArgs } from "node:util";
 import { UserService } from "./UserService.ts";
 import readline from "readline";
 
@@ -34,26 +34,37 @@ async function hashDryRun(sourceValue: string) {
  */
 async function main() {
   console.log("This process is your pid " + process.pid);
-  const args = minimist(process.argv.slice(2), {
-    string: ["host", "knownHost"],
-    number: ["port", "knownPort", "id"],
-  } as minimist.Opts);
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      host: { type: "string" },
+      port: { type: "string" },
+      knownHost: { type: "string" },
+      knownPort: { type: "string" },
+      id: { type: "string" },
+      hashOnly: { type: "string" },
+    },
+  });
 
-  if (args.hashOnly) {
-    const rc = await hashDryRun(args.hashOnly);
+  if (values.hashOnly) {
+    const rc = await hashDryRun(values.hashOnly);
     process.exit(rc);
   }
+
+  const port = values.port !== undefined ? Number(values.port) : undefined;
+  const id = values.id !== undefined ? Number(values.id) : undefined;
 
   // sanitize parameters corresponding to known node
   // + if no known host or port were provided, it is assumed that they are self's
   // + such as when starting a new chord; ie, joining itself
-  let knownNodeHost = args.knownHost ? args.knownHost : args.host;
-  let knownNodePort = args.knownPort ? args.knownPort : args.port;
+  const knownNodeHost = values.knownHost ?? values.host ?? null;
+  const knownNodePort =
+    values.knownPort !== undefined ? Number(values.knownPort) : (port ?? null);
 
   // protect against bad ID inputs
-  if (args.id && args.id > 2 ** HASH_BIT_LENGTH - 1) {
+  if (id !== undefined && id > 2 ** HASH_BIT_LENGTH - 1) {
     console.error(
-      `Error. Bad ID {${args.id}} > 2^m-1 {${
+      `Error. Bad ID {${id}} > 2^m-1 {${
         2 ** HASH_BIT_LENGTH - 1
       }}. Terminating...\n`,
     );
@@ -61,13 +72,13 @@ async function main() {
   }
 
   let userServiceNode = new UserService({
-    id: args.id,
-    host: args.host,
-    port: args.port,
+    id,
+    host: values.host,
+    port,
   });
   try {
     userServiceNode.serve();
-    let knownNode = {
+    const knownNode = {
       id: null,
       host: knownNodeHost,
       port: knownNodePort,

--- a/client/client.ts
+++ b/client/client.ts
@@ -1,12 +1,33 @@
-import minimist from "minimist";
+import { parseArgs } from "node:util";
 import { Client, type InsertArgs, type EditArgs } from "./common.ts";
 
 const VALID_COMMANDS =
   "lookup, insert, edit, remove, bulkInsert, summary, health, fingerTable, predecessor, successor";
 
 function main() {
-  const args = minimist(process.argv.slice(2));
-  const command = args._[0];
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      host: { type: "string" },
+      port: { type: "string" },
+      id: { type: "string" },
+      path: { type: "string" },
+      reputation: { type: "string" },
+      creationDate: { type: "string" },
+      displayName: { type: "string" },
+      lastAccessDate: { type: "string" },
+      websiteUrl: { type: "string" },
+      location: { type: "string" },
+      aboutMe: { type: "string" },
+      views: { type: "string" },
+      upVotes: { type: "string" },
+      downVotes: { type: "string" },
+      profileImageUrl: { type: "string" },
+      accountId: { type: "string" },
+    },
+    allowPositionals: true,
+  });
+  const command = positionals[0];
 
   if (!command) {
     console.error("Usage: node client.ts <command> [options]");
@@ -14,27 +35,47 @@ function main() {
     process.exit(1);
   }
 
-  const host: string = args.host || "localhost";
-  const port: number = args.port || 8440;
+  const host: string = values.host || "localhost";
+  const port: number = values.port ? Number(values.port) : 8440;
   const client = new Client(host, port);
+
+  // parseArgs yields string values for all options; coerce numerics at this
+  // boundary. insert()/edit() validate id and (for edit) the at-least-one-field
+  // rule at runtime.
+  const num = (v: string | undefined) =>
+    v !== undefined ? Number(v) : undefined;
 
   switch (command) {
     case "lookup":
-      client.lookup({ id: args.id });
+      client.lookup({ id: num(values.id) });
       break;
     case "remove":
-      client.remove({ id: args.id });
+      client.remove({ id: num(values.id) });
       break;
     case "bulkInsert":
-      client.bulkInsert({ path: args.path });
+      client.bulkInsert({ path: values.path });
       break;
-    // minimist yields untyped args, so cast at this boundary; insert()/edit()
-    // validate id and (for edit) the at-least-one-field rule at runtime.
     case "insert":
-      client.insert(args as unknown as InsertArgs);
+      client.insert({
+        ...values,
+        id: Number(values.id),
+        reputation: num(values.reputation),
+        views: num(values.views),
+        upVotes: num(values.upVotes),
+        downVotes: num(values.downVotes),
+        accountId: num(values.accountId),
+      } as unknown as InsertArgs);
       break;
     case "edit":
-      client.edit(args as unknown as EditArgs);
+      client.edit({
+        ...values,
+        id: Number(values.id),
+        reputation: num(values.reputation),
+        views: num(values.views),
+        upVotes: num(values.upVotes),
+        downVotes: num(values.downVotes),
+        accountId: num(values.accountId),
+      } as unknown as EditArgs);
       break;
     case "summary":
       client.summary();

--- a/client/common.ts
+++ b/client/common.ts
@@ -155,8 +155,8 @@ export class Client {
   }
 
   async insert(args: InsertArgs) {
-    // The CLI dispatches untyped minimist args, so guard `id` at runtime even
-    // though the type marks it required for programmatic callers.
+    // Guard `id` at runtime even though the type marks it required for
+    // programmatic callers — the CLI passes parsed-but-untyped args here.
     if (!args.id) {
       console.log("id is a mandatory field!");
       console.log("node client insert --id=42424242");
@@ -205,8 +205,8 @@ export class Client {
   }
 
   async edit(args: EditArgs) {
-    // The CLI dispatches untyped minimist args, so re-check `id` and the
-    // at-least-one-field rule at runtime; `EditArgs` enforces them for typed
+    // Re-check `id` and the at-least-one-field rule at runtime — the CLI
+    // passes parsed-but-untyped args here; `EditArgs` enforces them for typed
     // callers. A no-field edit would otherwise overwrite the user with a
     // bare { id }, wiping every other field server-side.
     if (!args.id) {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,10 @@
     "@grpc/grpc-js": "^1.12.5",
     "@grpc/proto-loader": "^0.8.1",
     "express": "^5.2.1",
-    "minimist": "^1.2.8",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/minimist": "^1.2.5",
     "@types/xml2js": "^0.4.14",
     "husky": "^9.0.0",
     "is-ci": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      minimist:
-        specifier: ^1.2.8
-        version: 1.2.8
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -27,9 +24,6 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
-      '@types/minimist':
-        specifier: ^1.2.5
-        version: 1.2.5
       '@types/xml2js':
         specifier: ^0.4.14
         version: 0.4.14
@@ -127,9 +121,6 @@ packages:
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
-
-  '@types/minimist@1.2.5':
-    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -379,9 +370,6 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -703,8 +691,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/minimist@1.2.5': {}
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -950,8 +936,6 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
-
-  minimist@1.2.8: {}
 
   mri@1.2.0: {}
 

--- a/web/web.ts
+++ b/web/web.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import minimist from "minimist";
+import { parseArgs } from "node:util";
 import os from "os";
 import path from "path";
 import { connect } from "../app/utils.ts";
@@ -197,15 +197,23 @@ class ChordCrawler {
 }
 
 function main() {
-  const args = minimist(process.argv.slice(2));
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      host: { type: "string" },
+      port: { type: "string" },
+      webPort: { type: "string" },
+      interval: { type: "string" },
+    },
+  });
   const crawler = new ChordCrawler(
-    args.host || DEFAULT_HOST_NAME,
-    args.port || 8440,
-    args.interval || CRAWLER_INTERVAL_MS,
+    values.host || DEFAULT_HOST_NAME,
+    values.port ? Number(values.port) : 8440,
+    values.interval ? Number(values.interval) : CRAWLER_INTERVAL_MS,
   );
 
   const app = express();
-  const port = args.webPort || 1337;
+  const port = values.webPort ? Number(values.webPort) : 1337;
   app.use(express.static(PUBLIC_PATH));
   app.get("/data", (_, res) => res.json(crawler.state));
   app.listen(port, () => console.log(`Example app listening on port ${port}!`));


### PR DESCRIPTION
## Summary

- Removes `minimist` (unmaintained since 2023-02-09) and `@types/minimist` from dependencies
- Replaces all three usages (`app/node.ts`, `client/client.ts`, `web/web.ts`) with `parseArgs` from the built-in `node:util` module (stable since Node 18.3; fully typed via `@types/node`)
- Numeric CLI options (`port`, `knownPort`, `id`, `reputation`, `views`, etc.) are coerced with `Number()` at each call site since `parseArgs` supports only `string` and `boolean` types
- Positional arguments (the command name in the client) use `allowPositionals: true` and `positionals[0]` instead of `args._[0]`
- Stale `minimist` references in comments in `client/common.ts` updated

## Test plan

- [ ] `pnpm run typecheck` passes (verified clean)
- [ ] `npm run devServer -- --port 8440` starts a node
- [ ] `npm run client -- insert --port 8440 --id 2` inserts a user
- [ ] `npm run client -- lookup --port 8440 --id 2` retrieves it
- [ ] `npm run devWeb -- --port 8440 --webPort 1337` starts the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)