### PR TITLE
fix: move fast-xml-parser to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "@grpc/grpc-js": "^1.12.5",
     "@grpc/proto-loader": "^0.8.1",
     "express": "^5.2.1",
-    "fast-xml-parser": "^5.8.0",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "fast-xml-parser": "^5.8.0",
     "husky": "^9.0.0",
     "is-ci": "^4.1.0",
     "prettier": "^3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      fast-xml-parser:
-        specifier: ^5.8.0
-        version: 5.8.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -27,6 +24,9 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
+      fast-xml-parser:
+        specifier: ^5.8.0
+        version: 5.8.0
       husky:
         specifier: ^9.0.0
         version: 9.1.7


### PR DESCRIPTION
## Summary

`fast-xml-parser` is only used in `data/cleanData.ts`, a one-off data-prep script that converts the StackOverflow XML dump to JSON. The production server never imports it. `xml2js` had the same misclassification before it was replaced in #220.

Moving it to `devDependencies` keeps the production dependency footprint accurate.

## Test plan
- [x] `pnpm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)