### PR TITLE
fix: tighten findPredecessor loop guard to a multiple of HASH_BIT_LENGTH (closes #75)

### DIFF
--- a/app/ChordNode.ts
+++ b/app/ChordNode.ts
@@ -184,8 +184,15 @@ export abstract class ChordNode {
   }
 
   /**
-   * This function directly implements the pseudocode's findPredecessor() method,
-   *  with the exception of the limits on the while loop.
+   * This function directly implements the pseudocode's findPredecessor() method.
+   *
+   * The Chord paper (Stoica et al., SIGCOMM '01, §4.2 and Theorem IV.2) proves
+   * that findPredecessor converges in O(log N) hops with high probability, where
+   * N <= 2 ** HASH_BIT_LENGTH, so log N is bounded above by HASH_BIT_LENGTH. The
+   * while loop therefore needs only a small multiple of HASH_BIT_LENGTH as a
+   * safety valve: enough headroom to absorb transient routing inconsistencies
+   * during churn, but small enough that a genuinely non-converging loop bails
+   * quickly rather than spinning through billions of remote round trips.
    * @param {number} id the key sought
    */
   async findPredecessor(id: number) {
@@ -204,11 +211,15 @@ export abstract class ChordNode {
       `findPredecessor: before while: nPrime = ${nPrime.id}; nPrimeSuccessor = ${nPrimeSuccessor.id}`,
     );
 
-    let iterationCounter = 2 ** HASH_BIT_LENGTH * HASH_BIT_LENGTH;
+    // Worst-case hop count is O(log N) <= HASH_BIT_LENGTH; the 4x multiplier is
+    // generous headroom for routing inconsistencies during churn. If we ever
+    // exhaust this budget, the ring is inconsistent and we stop rather than spin.
+    const maxIterations = HASH_BIT_LENGTH * 4;
+    let iterationCounter = maxIterations;
     while (
       !isInModuloRange(id, nPrime.id, false, nPrimeSuccessor.id, true) &&
       nPrime.id !== nPrimeSuccessor.id &&
-      iterationCounter >= 0
+      iterationCounter > 0
     ) {
       // loop should exit if n' and its successor are the same
       // loop should exit if the iterations are ridiculous
@@ -236,6 +247,12 @@ export abstract class ChordNode {
 
       this.logger.debug(
         `findPredecessor: nPrimeSuccessor = ${nPrimeSuccessor.id}`,
+      );
+    }
+
+    if (iterationCounter === 0) {
+      this.logger.warn(
+        `findPredecessor: exhausted iteration budget of ${maxIterations} hops for id = ${id}; ring is likely inconsistent, returning nPrime = ${nPrime.id}`,
       );
     }
 


### PR DESCRIPTION
## What changed

`findPredecessor` in `app/ChordNode.ts` used a while-loop guard of `2 ** HASH_BIT_LENGTH * HASH_BIT_LENGTH` — with `HASH_BIT_LENGTH = 32` that is ~1.37 × 10¹¹ (137 billion) iterations. Each iteration makes two remote gRPC round trips (`closestPrecedingFinger` + `getSuccessor`), so this 'exit if the iterations are ridiculous' safety valve would let a non-converging loop spin effectively forever — an indefinite hang rather than a guard.

This PR:
- **Tightens the bound** to `HASH_BIT_LENGTH * 4` (128 with the current config).
- **Fixes an off-by-one** in the loop condition (`iterationCounter >= 0` → `> 0`) so the budget is exactly `maxIterations` iterations.
- **Adds a `logger.warn`** when the budget is exhausted, so hitting the guard surfaces as an observable signal of an inconsistent ring instead of failing silently.
- **Updates the doc comment** to cite the paper's convergence bound rather than flagging the loop limits as an unexplained deviation.

## Why

Per the Chord paper ([Stoica et al., SIGCOMM '01](https://pdos.csail.mit.edu/papers/chord:sigcomm01/chord_sigcomm.pdf), §4.2 / Theorem IV.2), `findPredecessor` converges in **O(log N)** hops with high probability, where N ≤ 2^`HASH_BIT_LENGTH`, so log N is bounded above by `HASH_BIT_LENGTH`. A guard on the order of a small multiple of `HASH_BIT_LENGTH` protects against routing inconsistencies during churn while staying well above the legitimate worst case — and bails in milliseconds instead of billions of remote round trips.

Closes #75.

## Notes for reviewers

- No test suite exists in this repo, so this was verified by `tsc --noEmit` (clean for `ChordNode.ts`) and static reasoning about the loop bounds.
- The `4×` multiplier is a judgement call — happy to adjust to plain `HASH_BIT_LENGTH` or another factor if preferred.