### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add an explicit root-level `permissions` block to `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

## Why

Resolves CodeQL code-scanning [alert #1](https://github.com/bushidocodes/chord-grpc/security/code-scanning/1) — rule `actions/missing-workflow-permissions` (CWE-275, medium severity).

The workflow declared no `permissions`, so its `GITHUB_TOKEN` inherited the repo/org default. For repos or orgs created before February 2023 that default is **read-write**, which over-privileges the token and violates least privilege.

## Why `contents: read` is sufficient

The single `ci` job only checks out the repo and runs `pnpm install` / `typecheck` / `test` / `prettier --check` / `pnpm audit`. None of these write to the repository, issues, PRs, or packages, so read-only `contents` covers it. Declaring it explicitly also (a) documents the workflow's actual needs and (b) keeps the token restricted even if the org/repo default changes or the workflow is copied elsewhere.

Placed at the workflow root so it applies to all current and future jobs in the file.

## Reviewer notes

- No behavior change to the build; CI steps are unchanged.
- Verified `ci.yml` is the only workflow file in `.github/workflows/`.